### PR TITLE
Use os.Exit

### DIFF
--- a/aws_signing_helper/serve.go
+++ b/aws_signing_helper/serve.go
@@ -10,10 +10,10 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -220,7 +220,7 @@ func Serve(port int, credentialsOptions CredentialsOpts) {
 	roleArn, err := arn.Parse(credentialsOptions.RoleArn)
 	if err != nil {
 		log.Println("invalid role ARN")
-		syscall.Exit(1)
+		os.Exit(1)
 	}
 
 	credentialProcessOutput, _ := GenerateCredentials(&credentialsOptions)
@@ -258,7 +258,7 @@ func Serve(port int, credentialsOptions CredentialsOpts) {
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", LocalHostAddress, endpoint.PortNum))
 	if err != nil {
 		log.Println("failed to create listener")
-		syscall.Exit(1)
+		os.Exit(1)
 	}
 	endpoint.PortNum = listener.Addr().(*net.TCPAddr).Port
 	log.Println("Local server started on port:", endpoint.PortNum)
@@ -266,6 +266,6 @@ func Serve(port int, credentialsOptions CredentialsOpts) {
 	log.Printf("export AWS_EC2_METADATA_SERVICE_ENDPOINT=http://%s:%d/", LocalHostAddress, endpoint.PortNum)
 	if err := endpoint.Server.Serve(listener); err != nil {
 		log.Println("Httpserver: ListenAndServe() error")
-		syscall.Exit(1)
+		os.Exit(1)
 	}
 }

--- a/aws_signing_helper/update.go
+++ b/aws_signing_helper/update.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -39,21 +38,21 @@ func Update(credentialsOptions CredentialsOpts, profile string, once bool) {
 		refreshableCred.Expiration, _ = time.Parse(time.RFC3339, credentialProcessOutput.Expiration)
 		if (refreshableCred == TemporaryCredential{}) {
 			log.Println("no credentials created")
-			syscall.Exit(1)
+			os.Exit(1)
 		}
 
 		// Get credentials file contents
 		lines, err := GetCredentialsFileContents()
 		if err != nil {
 			log.Println("unable to get credentials file contents")
-			syscall.Exit(1)
+			os.Exit(1)
 		}
 
 		// Write to credentials file
 		err = WriteTo(profile, lines, &refreshableCred)
 		if err != nil {
 			log.Println("unable to write to AWS credentials file")
-			syscall.Exit(1)
+			os.Exit(1)
 		}
 
 		if once {
@@ -85,7 +84,7 @@ func GetCredentialsFileContents() ([]string, error) {
 	readOnlyCredentialsFile, err := os.OpenFile(awsCredentialsPath, os.O_RDONLY|os.O_CREATE, 0600)
 	if err != nil {
 		log.Println("unable to get or create read-only AWS credentials file")
-		syscall.Exit(1)
+		os.Exit(1)
 	}
 	defer readOnlyCredentialsFile.Close()
 
@@ -113,7 +112,7 @@ func WriteTo(profileName string, writeLines []string, cred *TemporaryCredential)
 	destFile, err := GetWriteOnlyCredentialsFile()
 	if err != nil {
 		log.Println("unable to get write-only AWS credentials file")
-		syscall.Exit(1)
+		os.Exit(1)
 	}
 	defer destFile.Close()
 

--- a/cmd/aws_signing_helper/main.go
+++ b/cmd/aws_signing_helper/main.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"syscall"
 
 	helper "github.com/aws/rolesanywhere-credential-helper/aws_signing_helper"
 )
@@ -64,7 +63,7 @@ var commands = map[string]*flag.FlagSet{
 
 // Finds global parameters that can appear in any position
 // Return a map that maps the name of global parameter to its value
-//		and a list of remaining arguments
+// and a list of remaining arguments
 func findGlobalVar(argList []string) (map[string]string, []string) {
 	globalVars := make(map[string]string)
 
@@ -79,7 +78,7 @@ func findGlobalVar(argList []string) (map[string]string, []string) {
 				i = i + 1
 			} else {
 				log.Println("Invalid value for ", argList[i])
-				syscall.Exit(1)
+				os.Exit(1)
 			}
 		} else {
 			parseList = append(parseList, argList[i])
@@ -132,7 +131,7 @@ func main() {
 	tmpEndpoint, endpointDetected := globalVars["--endpoint"]
 	if len(parseList) == 0 || strings.HasPrefix(parseList[0], "--") {
 		log.Println("No command provided")
-		syscall.Exit(1)
+		os.Exit(1)
 	}
 
 	command := parseList[0]
@@ -140,7 +139,7 @@ func main() {
 	// if the command does not exist in the command list
 	if !valid {
 		log.Println("Unrecognized command")
-		syscall.Exit(1)
+		os.Exit(1)
 	}
 
 	commandFs.Parse(parseList[1:])
@@ -187,12 +186,12 @@ func main() {
 			[--debug]
 			[--intermediates <value>]`
 			log.Println(msg)
-			syscall.Exit(1)
+			os.Exit(1)
 		}
 		credentialProcessOutput, err := helper.GenerateCredentials(&credentialsOptions)
 		if err != nil {
 			log.Println(err)
-			syscall.Exit(1)
+			os.Exit(1)
 		}
 		buf, _ := json.Marshal(credentialProcessOutput)
 		fmt.Print(string(buf[:]))
@@ -247,7 +246,7 @@ func main() {
 			[--profile <value>]
 			[--once]`
 			log.Println(msg)
-			syscall.Exit(1)
+			os.Exit(1)
 		}
 		helper.Update(credentialsOptions, profile, once)
 	case "serve":
@@ -269,12 +268,12 @@ func main() {
 			[--intermediates <value>]
 			[--port <value>]`
 			log.Println(msg)
-			syscall.Exit(1)
+			os.Exit(1)
 		}
 		helper.Serve(port, credentialsOptions)
 	case "":
 		log.Println("No command provided")
-		syscall.Exit(1)
+		os.Exit(1)
 	default:
 		log.Fatalf("Unrecognized command %s", command)
 	}


### PR DESCRIPTION
In my opinion, [the syscall package is locked down](https://pkg.go.dev/syscall) and `os.Exit` should be used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
