### PR TITLE
Replace io/ioutil functions

### DIFF
--- a/aws_signing_helper/serve.go
+++ b/aws_signing_helper/serve.go
@@ -138,7 +138,7 @@ func FindTokenTTLSeconds(r *http.Request) (string, error) {
 	expiration, ok := tokenMap[token]
 	mutex.Unlock()
 	if ok {
-		tokenTTLFloat := expiration.Sub(time.Now()).Seconds()
+		tokenTTLFloat := time.Until(expiration).Seconds()
 		tokenTTLInt64 := int64(tokenTTLFloat)
 		return strconv.FormatInt(tokenTTLInt64, 10), nil
 	} else {

--- a/aws_signing_helper/signer_test.go
+++ b/aws_signing_helper/signer_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -443,7 +442,7 @@ aws_secret_access_key = test`,
 
 			Update(credentialsOpts, tc.profile, true)
 
-			fileByteContents, _ := ioutil.ReadFile(TestCredentialsFilePath)
+			fileByteContents, _ := os.ReadFile(TestCredentialsFilePath)
 			fileStringContents := trimLastChar(string(fileByteContents))
 			if fileStringContents != tc.expectedFileContents {
 				t.Log("unexpected file contents")
@@ -488,7 +487,7 @@ aws_session_token = sessionToken
 
 			Update(credentialsOpts, tc.profile, true)
 
-			fileByteContents, _ := ioutil.ReadFile(TestCredentialsFilePath)
+			fileByteContents, _ := os.ReadFile(TestCredentialsFilePath)
 			fileStringContents := trimLastChar(string(fileByteContents))
 			if fileStringContents != tc.expectedFileContents {
 				t.Log("unexpected file contents")

--- a/cmd/aws_signing_helper/main.go
+++ b/cmd/aws_signing_helper/main.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -196,7 +196,7 @@ func main() {
 		buf, _ := json.Marshal(credentialProcessOutput)
 		fmt.Print(string(buf[:]))
 	case "sign-string":
-		stringToSign, _ := ioutil.ReadAll(bufio.NewReader(os.Stdin))
+		stringToSign, _ := io.ReadAll(bufio.NewReader(os.Stdin))
 		privateKey, _ := helper.ReadPrivateKeyData(privateKeyId)
 		var digest crypto.Hash
 		switch strings.ToUpper(digestArg) {


### PR DESCRIPTION
*Description of changes:*

This commit fixes the following warning by [staticcheck](https://staticcheck.io/)

```
aws_signing_helper/serve.go:141:20: should use time.Until instead of t.Sub(time.Now()) (S1024)
aws_signing_helper/signer_test.go:15:2: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
cmd/aws_signing_helper/main.go:11:2: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
