### PR TITLE
RolesAnywhere-4197: Fix file overwriting bug in update command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.0.4
+VERSION=1.0.5
 
 release:
 	go build -buildmode=pie -ldflags "-X 'main.Version=${VERSION}' -linkmode=external -w -s" -trimpath -o build/bin/aws_signing_helper cmd/aws_signing_helper/main.go


### PR DESCRIPTION
*Description of changes:*

Fix bug in file overwriting for the update command. One example of when this bug occurs is when a new session token is shorter than the previous token, causing the resulting line to retain characters from the old session token. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
