### PR TITLE
Role arns

### DIFF
--- a/aws_signing_helper/credentials.go
+++ b/aws_signing_helper/credentials.go
@@ -20,7 +20,7 @@ type CredentialsOpts struct {
 	CertificateId       string
 	CertificateBundleId string
 	CertIdentifier      CertIdentifier
-	RoleArn             string
+	RoleArn             []string
 	ProfileArnStr       string
 	TrustAnchorArnStr   string
 	SessionDuration     int
@@ -98,13 +98,16 @@ func GenerateCredentials(opts *CredentialsOpts, signer Signer, signatureAlgorith
 
 	certificateStr := base64.StdEncoding.EncodeToString(certificate.Raw)
 	durationSeconds := int64(opts.SessionDuration)
+        var firstRoleArn string
+        var remainingRoleArns []string
+        firstRoleArn, remainingRoleArns = opts.RoleArn[0], opts.RoleArn[1:]
 	createSessionRequest := rolesanywhere.CreateSessionInput{
 		Cert:               &certificateStr,
 		ProfileArn:         &opts.ProfileArnStr,
 		TrustAnchorArn:     &opts.TrustAnchorArnStr,
 		DurationSeconds:    &(durationSeconds),
 		InstanceProperties: nil,
-		RoleArn:            &opts.RoleArn,
+		RoleArn:            &firstRoleArn,
 		SessionName:        nil,
 	}
 	output, err := rolesAnywhereClient.CreateSession(&createSessionRequest)

--- a/aws_signing_helper/credentials.go
+++ b/aws_signing_helper/credentials.go
@@ -26,6 +26,7 @@ type CredentialsOpts struct {
 	RoleArn             []string
 	ProfileArnStr       string
 	TrustAnchorArnStr   string
+	RoleSessionName     []string
 	SessionDuration     int
 	Region              string
 	Endpoint            string
@@ -138,9 +139,13 @@ func GenerateCredentials(opts *CredentialsOpts, signer Signer, signatureAlgorith
                 ),
 	    })
             stsClient := sts.New(sess)
+            rsn := "my-session"
+            if len(opts.RoleSessionName) > i {
+              rsn = opts.RoleSessionName[i]
+            }
             stsRequest := sts.AssumeRoleInput{
                 RoleArn:         aws.String(remainingRoleArns[i]),
-                RoleSessionName: aws.String("my-role-test"),
+                RoleSessionName: aws.String(rsn),
                 DurationSeconds: aws.Int64(durationSeconds), //min allowed
             }
 

--- a/aws_signing_helper/credentials.go
+++ b/aws_signing_helper/credentials.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"runtime"
+        "fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -120,6 +121,11 @@ func GenerateCredentials(opts *CredentialsOpts, signer Signer, signatureAlgorith
 		return CredentialProcessOutput{}, errors.New(msg)
 	}
 	credentials := output.CredentialSet[0].Credentials
+        var currentRoleArn = firstRoleArn
+        for i := 0; i < len(remainingRoleArns); i++ {
+            fmt.Printf("use %s to assume %s",currentRoleArn,remainingRoleArns[i])
+            currentRoleArn = remainingRoleArns[i]
+        }
 	credentialProcessOutput := CredentialProcessOutput{
 		Version:         1,
 		AccessKeyId:     *credentials.AccessKeyId,

--- a/aws_signing_helper/serve.go
+++ b/aws_signing_helper/serve.go
@@ -262,7 +262,7 @@ func AllIssuesHandlers(cred *RefreshableCred, roleName string, opts *Credentials
 func Serve(port int, credentialsOptions CredentialsOpts) {
 	var refreshableCred = RefreshableCred{}
 
-	roleArn, err := arn.Parse(credentialsOptions.RoleArn)
+	roleArn, err := arn.Parse(credentialsOptions.RoleArn[0])
 	if err != nil {
 		log.Println("invalid role ARN")
 		os.Exit(1)

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -15,6 +15,7 @@ var (
 	roleArnStr        []string
 	profileArnStr     string
 	trustAnchorArnStr string
+	roleSessionName   []string
 	sessionDuration   int
 	region            string
 	endpoint          string
@@ -55,6 +56,7 @@ func initCredentialsSubCommand(subCmd *cobra.Command) {
 	subCmd.PersistentFlags().StringArrayVarP(&roleArnStr, "role-arn", "", []string{}, "Target role(s) to assume one-by-one, in order specified")
 	subCmd.PersistentFlags().StringVar(&profileArnStr, "profile-arn", "", "Profile to pull policies from")
 	subCmd.PersistentFlags().StringVar(&trustAnchorArnStr, "trust-anchor-arn", "", "Trust anchor to use for authentication")
+	subCmd.PersistentFlags().StringArrayVarP(&roleSessionName, "role-session-name", "", []string{}, "Session names for additional roles specified in --role-arn arguments")
 	subCmd.PersistentFlags().IntVar(&sessionDuration, "session-duration", 3600, "Duration, in seconds, for the resulting session")
 	subCmd.PersistentFlags().StringVar(&region, "region", "", "Signing region")
 	subCmd.PersistentFlags().StringVar(&endpoint, "endpoint", "", "Endpoint used to call CreateSession")
@@ -233,6 +235,7 @@ func PopulateCredentialsOptions() error {
 		RoleArn:             roleArnStr,
 		ProfileArnStr:       profileArnStr,
 		TrustAnchorArnStr:   trustAnchorArnStr,
+                RoleSessionName:     roleSessionName,
 		SessionDuration:     sessionDuration,
 		Region:              region,
 		Endpoint:            endpoint,

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	roleArnStr        string
+	roleArnStr        []string
 	profileArnStr     string
 	trustAnchorArnStr string
 	sessionDuration   int
@@ -52,7 +52,7 @@ type MapEntry struct {
 // Parses common flags for commands that vend credentials
 func initCredentialsSubCommand(subCmd *cobra.Command) {
 	rootCmd.AddCommand(subCmd)
-	subCmd.PersistentFlags().StringVar(&roleArnStr, "role-arn", "", "Target role to assume")
+	subCmd.PersistentFlags().StringArrayVarP(&roleArnStr, "role-arn", "", []string{}, "Target role(s) to assume one-by-one, in order specified")
 	subCmd.PersistentFlags().StringVar(&profileArnStr, "profile-arn", "", "Profile to pull policies from")
 	subCmd.PersistentFlags().StringVar(&trustAnchorArnStr, "trust-anchor-arn", "", "Trust anchor to use for authentication")
 	subCmd.PersistentFlags().IntVar(&sessionDuration, "session-duration", 3600, "Duration, in seconds, for the resulting session")


### PR DESCRIPTION
Suppose you have a multiple accounts with AWS Organizations deployed. You might have a Security OU with a Security account, and you might have many workload accounts. Suppose you also have various on-prem hosts that need to assume roles in the workload accounts. 

### Ideal scenario
In the ideal scenario, there is 1 AWS account, managed by the information security team, that contains the trust anchor(s) and Roles Anywhere profiles.
```
                                                         *** SECURITY OU ***                                                              *** WORKLOAD OU ***
on-prem host 1 ---\                                                                                                        /------- IAM role in workload account 1
on-prem host 2 -------->   [ trust anchor in security account ] --- > [ Roles Anywhere profile in security account] -->  ---------- IAM role in workload account 2
on-prem host n ---/                                                                                                        \------- IAM role in workload account n
```

### Why you couldn't have the ideal scenario
The signing tool and/or IAM/STS in general do not allow cross-account pass role. So you can not create a Roles Anywhere profile for a role ARN in another account, nor can you pass a `--profile-arn` and `--role-arn` to the `aws_signing_helper` if those two ARNs are in different AWS accounts, as this will result in a `cross-account pass role is not allowed` error.


### Not ideal scenario, but it works
Because the ideal scenario couldn't be had, the trust anchor and profiles have to exist in each workload account. This is cumbersome for a security team to maintain at scale.
```
                                             ***               REPEATED IN EACH WORKLOAD OU                    ***
on-prem host 1 -------->   [ trust anchor and Roles Anywhere profile in workload account 1 ] ---------->  IAM role in workload account 1
on-prem host 2 -------->   [ trust anchor and Roles Anywhere profile in workload account 2 ] ---------->  IAM role in workload account 2
on-prem host n -------->   [ trust anchor and Roles Anywhere profile in workload account n ] ---------->  IAM role in workload account n
```

### What this pull request does
Perhaps it easier to explain with code examples
#### before
You can only use the `aws_signing_helper` to get credentials for one role ARN.
```
/path/to/aws_signing_helper credential-process \
    --certificate credential-process-data/client-cert.pem \
    --private-key credential-process-data/client-key.pem \
    --role-arn arn:aws:iam::111111111111:role/test-roles-anywhere \
    --trust-anchor-arn arn:aws:rolesanywhere:us-west-2:111111111111:trust-anchor/abcdef-012345 \
    --profile-arn arn:aws:rolesanywhere:us-west-2:111111111111:profile/fedcba-654987
```

#### after
You can specify `--role_arn` over and over again. The first `--role-arn` is used to retrieve credentials from Roles Anywhere. Subsequent `--role-arn` arguments pass those credentials to `sts:AssumeRole` to assume the next role.
```
/path/to/aws_signing_helper credential-process \
    --certificate credential-process-data/client-cert.pem \
    --private-key credential-process-data/client-key.pem \
    --role-arn arn:aws:iam::111111111111:role/test-roles-anywhere \
    --role-arn arn:aws:iam::222222222222:role/desired-role \                                       # THIS!
    --trust-anchor-arn arn:aws:rolesanywhere:us-west-2:111111111111:trust-anchor/abcdef-012345 \
    --profile-arn arn:aws:rolesanywhere:us-west-2:111111111111:profile/fedcba-654987
```

#### bigger example
You can specify `--role_arn` over and over again, and you can override the default `sts:AssumeRole role-session-name` of `my-session`
```
/path/to/aws_signing_helper credential-process \
    --certificate credential-process-data/client-cert.pem \
    --private-key credential-process-data/client-key.pem \
    --role-arn arn:aws:iam::111111111111:role/test-roles-anywhere \
    --role-arn arn:aws:iam::222222222222:role/intermediate-role \     # the credentials retrieved for the first --role-arn are used to retrieve credentials for this role arn
    --role-session-name my-first-session
    --role-arn arn:aws:iam::222222222222:role/final-role \            # the credentials retrieved for the second --role-arn are used to retrieve credentials for this role arn
    --role-session-name my-second-session
    --trust-anchor-arn arn:aws:rolesanywhere:us-west-2:111111111111:trust-anchor/abcdef-012345 \
    --profile-arn arn:aws:rolesanywhere:us-west-2:111111111111:profile/fedcba-654987
```

### Summary
* if you specify `--role-arn` one time, then the credential helper works as it always did
* if you specify `--role-arn` more than once, then the credential helper works as it always did for the first `--role-arn`, then it does `sts:Assume` role for the subsequent `--role-arn` arguments
* the result is the same: the output of the credential helper is a JSON object containing a Version, AccessKeyId, SecretAccessKey, SessionToken, and Expiration