### PR TITLE
Remove extra hardcoded default port in help for aws_signing_helper serve command

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -14,7 +14,7 @@ var (
 
 func init() {
 	initCredentialsSubCommand(serveCmd)
-	serveCmd.PersistentFlags().IntVar(&port, "port", helper.DefaultPort, "The port used to run the local server (default: 9911)")
+	serveCmd.PersistentFlags().IntVar(&port, "port", helper.DefaultPort, "The port used to run the local server")
 }
 
 var serveCmd = &cobra.Command{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Help for `aws_signing_helper serve` command prints the default port two twice. The one separated with colon is hardcoded and do not reflect changes of `DefaultPort` in `aws_signing_helper/serve.go`. 

The changes in pull request removes the extra hardcoded default port from help section.

```sh
aws_signing_helper serve --help
```
 before
 ```
…
       --port int                   The port used to run the local server (default: 9911) (default 9911)
…
 ```

 after
 ```
…
       --port int                   The port used to run the local server (default 9911)
…
 ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.