### PR TITLE
feat(serve): Add configurable TTL to serve responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ When you use `serve` AWS SDKs will be able to discover the credentials from the 
 
 When using `serve` it is important to understand that processes running on a system that can reach 127.0.0.1 will be able to retrieve AWS credentials from the credential helper. 
 
+The `serve` command also supports a `--hop-limit` flag to limit the IP TTL on response packets. This defaults to a value of 64 but can be set to a value of 1 to maintain parity with EC2's IMDSv2 hop count behavior.
+
 ### Scripts
 
 The project also comes with two bash scripts at its root, called `generate-certs.sh` and `generate-credential-process-data.sh`. Note that these scripts currently only work on Unix-based systems and require `openssl` to be installed.

--- a/aws_signing_helper/credentials.go
+++ b/aws_signing_helper/credentials.go
@@ -32,6 +32,7 @@ type CredentialsOpts struct {
 	Version             string
 	LibPkcs11           string
 	ReusePin            bool
+	ServerTTL           int
 }
 
 // Function to create session and generate credentials

--- a/aws_signing_helper/serve.go
+++ b/aws_signing_helper/serve.go
@@ -20,6 +20,7 @@ import (
 )
 
 const DefaultPort = 9911
+const DefaultHopLimit = 64
 const LocalHostAddress = "127.0.0.1"
 
 var RefreshTime = time.Minute * time.Duration(5)
@@ -325,6 +326,7 @@ func Serve(port int, credentialsOptions CredentialsOpts) {
 		log.Println("failed to create listener")
 		os.Exit(1)
 	}
+	listener = NewListenerWithTTL(listener, credentialsOptions.ServerTTL)
 	endpoint.PortNum = listener.Addr().(*net.TCPAddr).Port
 	log.Println("Local server started on port:", endpoint.PortNum)
 	log.Println("Make it available to the sdk by running:")

--- a/aws_signing_helper/ttl_listener.go
+++ b/aws_signing_helper/ttl_listener.go
@@ -1,0 +1,42 @@
+package aws_signing_helper
+
+import (
+	"net"
+
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+type ttlListener struct {
+	l   net.Listener
+	ttl int
+}
+
+// NewListenerWithTTL wraps a net.Listener and sets the TTL on outgoing packets to the specififed value
+func NewListenerWithTTL(l net.Listener, ttl int) net.Listener {
+	return &ttlListener{l, ttl}
+}
+
+func (w *ttlListener) Accept() (net.Conn, error) {
+	c, err := w.l.Accept()
+	if err != nil {
+		return nil, err
+	}
+	if c.RemoteAddr().(*net.TCPAddr).IP.To16() != nil && c.RemoteAddr().(*net.TCPAddr).IP.To4() == nil {
+		p := ipv6.NewConn(c)
+		if err := p.SetHopLimit(w.ttl); err != nil {
+			return nil, err
+		}
+	} else if c.RemoteAddr().(*net.TCPAddr).IP.To4() != nil {
+		p := ipv4.NewConn(c)
+		if err := p.SetTTL(w.ttl); err != nil {
+			return nil, err
+		}
+
+	}
+	return c, nil
+}
+
+func (w *ttlListener) Close() error { return w.l.Close() }
+
+func (w *ttlListener) Addr() net.Addr { return w.l.Addr() }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,12 +9,14 @@ import (
 )
 
 var (
-	port int
+	port     int
+	hopLimit int
 )
 
 func init() {
 	initCredentialsSubCommand(serveCmd)
 	serveCmd.PersistentFlags().IntVar(&port, "port", helper.DefaultPort, "The port used to run the local server")
+	serveCmd.PersistentFlags().IntVar(&hopLimit, "hop-limit", helper.DefaultHopLimit, "The IP TTL to set on responses")
 }
 
 var serveCmd = &cobra.Command{
@@ -29,6 +31,7 @@ var serveCmd = &cobra.Command{
 		}
 
 		helper.Debug = credentialsOptions.Debug
+		credentialsOptions.ServerTTL = hopLimit
 
 		helper.Serve(port, credentialsOptions)
 	},

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6
 	golang.org/x/crypto v0.20.0
+	golang.org/x/net v0.21.0
 	golang.org/x/sys v0.17.0
 	golang.org/x/term v0.17.0
 )

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6/go.mod h
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 golang.org/x/crypto v0.20.0 h1:jmAMJJZXr5KiCw05dfYK9QnqaqKLYXijU23lsEdcQqg=
 golang.org/x/crypto v0.20.0/go.mod h1:Xwo95rrVNIoSMx9wa1JroENMToLWn3RNVrTBpLHgZPQ=
+golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.17.0 h1:mkTF7LCd6WGJNL3K1Ad7kwxNfYAW6a8a8QqtMblp/4U=


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

For containerized environments, a TTL of 1 will prevent processes in other network namespaces from being able to reach the host level metadata. This matches EC2's IMDSv2 behavior for credential responses. The default value of 64 leaves existing behavior unchanged
