### PR TITLE
Fix FileSystemSigner with PKCS#12 files

### DIFF
--- a/aws_signing_helper/file_system_signer.go
+++ b/aws_signing_helper/file_system_signer.go
@@ -23,13 +23,13 @@ type FileSystemSigner struct {
 func (fileSystemSigner *FileSystemSigner) Public() crypto.PublicKey {
 	privateKey, _, _ := fileSystemSigner.readCertFiles()
 	{
-		privateKey, ok := privateKey.(ecdsa.PrivateKey)
+		privateKey, ok := privateKey.(*ecdsa.PrivateKey)
 		if ok {
 			return &privateKey.PublicKey
 		}
 	}
 	{
-		privateKey, ok := privateKey.(rsa.PrivateKey)
+		privateKey, ok := privateKey.(*rsa.PrivateKey)
 		if ok {
 			return &privateKey.PublicKey
 		}
@@ -56,17 +56,17 @@ func (fileSystemSigner *FileSystemSigner) Sign(rand io.Reader, digest []byte, op
 		return nil, ErrUnsupportedHash
 	}
 
-	ecdsaPrivateKey, ok := privateKey.(ecdsa.PrivateKey)
+	ecdsaPrivateKey, ok := privateKey.(*ecdsa.PrivateKey)
 	if ok {
-		sig, err := ecdsa.SignASN1(rand, &ecdsaPrivateKey, hash[:])
+		sig, err := ecdsa.SignASN1(rand, ecdsaPrivateKey, hash[:])
 		if err == nil {
 			return sig, nil
 		}
 	}
 
-	rsaPrivateKey, ok := privateKey.(rsa.PrivateKey)
+	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
 	if ok {
-		sig, err := rsa.SignPKCS1v15(rand, &rsaPrivateKey, opts.HashFunc(), hash[:])
+		sig, err := rsa.SignPKCS1v15(rand, rsaPrivateKey, opts.HashFunc(), hash[:])
 		if err == nil {
 			return sig, nil
 		}
@@ -91,11 +91,11 @@ func GetFileSystemSigner(privateKeyPath string, certPath string, bundlePath stri
 	fsSigner := &FileSystemSigner{bundlePath: bundlePath, certPath: certPath, isPkcs12: isPkcs12, privateKeyPath: privateKeyPath}
 	privateKey, _, _ := fsSigner.readCertFiles()
 	// Find the signing algorithm
-	_, isRsaKey := privateKey.(rsa.PrivateKey)
+	_, isRsaKey := privateKey.(*rsa.PrivateKey)
 	if isRsaKey {
 		signingAlgorithm = aws4_x509_rsa_sha256
 	}
-	_, isEcKey := privateKey.(ecdsa.PrivateKey)
+	_, isEcKey := privateKey.(*ecdsa.PrivateKey)
 	if isEcKey {
 		signingAlgorithm = aws4_x509_ecdsa_sha256
 	}

--- a/aws_signing_helper/pkcs11_signer_test.go
+++ b/aws_signing_helper/pkcs11_signer_test.go
@@ -1,0 +1,110 @@
+package aws_signing_helper
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPKCS11Signer(t *testing.T) {
+	testTable := []CredentialsOpts{}
+
+	pkcs11_objects := []string{"rsa-2048", "ec-prime256v1"}
+
+	for _, object := range pkcs11_objects {
+		base_pkcs11_uri := "pkcs11:token=credential-helper-test?pin-value=1234"
+		basic_pkcs11_uri := fmt.Sprintf("pkcs11:token=credential-helper-test;object=%s?pin-value=1234", object)
+		always_auth_pkcs11_uri := fmt.Sprintf("pkcs11:token=credential-helper-test;object=%s-always-auth?pin-value=1234", object)
+		cert_file := fmt.Sprintf("../tst/certs/%s-sha256-cert.pem", object)
+
+		testTable = append(testTable, CredentialsOpts{
+			CertificateId: basic_pkcs11_uri,
+		})
+		testTable = append(testTable, CredentialsOpts{
+			PrivateKeyId: basic_pkcs11_uri,
+		})
+		testTable = append(testTable, CredentialsOpts{
+			CertificateId: basic_pkcs11_uri,
+			PrivateKeyId:  basic_pkcs11_uri,
+		})
+		testTable = append(testTable, CredentialsOpts{
+			CertificateId: cert_file,
+			PrivateKeyId:  basic_pkcs11_uri,
+		})
+		testTable = append(testTable, CredentialsOpts{
+			CertificateId: basic_pkcs11_uri,
+			PrivateKeyId:  always_auth_pkcs11_uri,
+			ReusePin:      true,
+		})
+		testTable = append(testTable, CredentialsOpts{
+			CertificateId: cert_file,
+			PrivateKeyId:  always_auth_pkcs11_uri,
+			ReusePin:      true,
+		})
+		// Note that for the below test case, there are two matching keys.
+		// Both keys will validate with the certificate, and one will be chosen
+		// (it doesn't matter which, since both are the exact same key - it's
+		// just that one has the CKA_ALWAYS_AUTHENTICATE attribute set).
+		testTable = append(testTable, CredentialsOpts{
+			CertificateId: cert_file,
+			PrivateKeyId:  base_pkcs11_uri,
+			ReusePin:      true,
+		})
+	}
+
+	RunSignTestWithTestTable(t, testTable)
+}
+
+func TestPKCS11SignerCreationFails(t *testing.T) {
+	testTable := []CredentialsOpts{}
+
+	template_uri := "pkcs11:token=credential-helper-test;object=%s?pin-value=1234"
+	rsa_generic_uri := fmt.Sprintf(template_uri, "rsa-2048")
+	ec_generic_uri := fmt.Sprintf(template_uri, "ec-prime256v1")
+	always_auth_rsa_uri := fmt.Sprintf(template_uri, "rsa-2048-always-auth")
+	always_auth_ec_uri := fmt.Sprintf(template_uri, "ec-prime256v1-always-auth")
+
+	testTable = append(testTable, CredentialsOpts{
+		CertificateId: rsa_generic_uri,
+		PrivateKeyId:  ec_generic_uri,
+	})
+	testTable = append(testTable, CredentialsOpts{
+		CertificateId: ec_generic_uri,
+		PrivateKeyId:  rsa_generic_uri,
+	})
+	testTable = append(testTable, CredentialsOpts{
+		CertificateId: "../tst/certs/ec-prime256v1-sha256-cert.pem",
+		PrivateKeyId:  rsa_generic_uri,
+	})
+	testTable = append(testTable, CredentialsOpts{
+		CertificateId: "../tst/certs/rsa-2048-sha256-cert.pem",
+		PrivateKeyId:  ec_generic_uri,
+	})
+	testTable = append(testTable, CredentialsOpts{
+		CertificateId: rsa_generic_uri,
+		PrivateKeyId:  always_auth_ec_uri,
+		ReusePin:      true,
+	})
+	testTable = append(testTable, CredentialsOpts{
+		CertificateId: ec_generic_uri,
+		PrivateKeyId:  always_auth_rsa_uri,
+		ReusePin:      true,
+	})
+	testTable = append(testTable, CredentialsOpts{
+		CertificateId: "../tst/certs/ec-prime256v1-sha256-cert.pem",
+		PrivateKeyId:  always_auth_rsa_uri,
+		ReusePin:      true,
+	})
+	testTable = append(testTable, CredentialsOpts{
+		CertificateId: "../tst/certs/rsa-2048-sha256-cert.pem",
+		PrivateKeyId:  always_auth_ec_uri,
+		ReusePin:      true,
+	})
+
+	for _, credOpts := range testTable {
+		_, _, err := GetSigner(&credOpts)
+		if err == nil {
+			t.Log("Expected failure when creating PKCS#11 signer, but received none")
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
* Use *rsa.PrivateKey and *ec.PrivateKey types across the project to maintain consistency
* Refactor Makefile so that it's easy to run the subset of tests that don't require non-trivial dependencies

We may also want to change `sign-string` so that paths to PKCS#12 files can be passed in using the `--private-key` flag. Currently, the `--certificate` flag has to be used (even if the container only contains a private key). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
