### PR TITLE
Introduce `--use-latest-expiring-certificate` Option

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -7,6 +7,6 @@
     <key>CFBundleIdentifier</key>
     <string>com.amazon.aws.rolesanywhere</string>
     <key>CFBundleVersion</key>
-    <string>1.4.0</string>
+    <string>1.5.0</string>
 </dict>
 </plist>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.4.0
+VERSION=1.5.0
 
 .PHONY: release
 release: build/bin/aws_signing_helper

--- a/aws_signing_helper/cert_store_signer_darwin.go
+++ b/aws_signing_helper/cert_store_signer_darwin.go
@@ -180,7 +180,7 @@ func GetCertStoreSigner(certIdentifier CertIdentifier, useLatestExpiringCert boo
 	}
 	selectedCertContainer = certContainers[len(certContainers)-1]
 	if Debug {
-		log.Print(fmt.Sprintf("Selected certificate: %s", DefaultCertContainerToString(selectedCertContainer)))
+		log.Print(fmt.Sprintf("selected certificate: %s", DefaultCertContainerToString(selectedCertContainer)))
 	}
 	cert = selectedCertContainer.Cert
 	certRef = certRefs[selectedCertContainer.Index]

--- a/aws_signing_helper/cert_store_signer_darwin.go
+++ b/aws_signing_helper/cert_store_signer_darwin.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sort"
 	"unsafe"
 )
 
@@ -43,7 +44,7 @@ const (
 
 // Gets the matching identity and certificate for this CertIdentifier
 // If there is more than one, only a list of the matching certificates is returned
-func GetMatchingCertsAndIdentity(certIdentifier CertIdentifier) (C.SecIdentityRef, C.SecCertificateRef, []CertificateContainer, error) {
+func GetMatchingCertsAndIdentity(certIdentifier CertIdentifier) ([]C.SecIdentityRef, []C.SecCertificateRef, []CertificateContainer, error) {
 	queryMap := map[C.CFTypeRef]C.CFTypeRef{
 		C.CFTypeRef(C.kSecClass):      C.CFTypeRef(C.kSecClassIdentity),
 		C.CFTypeRef(C.kSecReturnRef):  C.CFTypeRef(C.kCFBooleanTrue),
@@ -52,16 +53,16 @@ func GetMatchingCertsAndIdentity(certIdentifier CertIdentifier) (C.SecIdentityRe
 
 	query := mapToCFDictionary(queryMap)
 	if query == 0 {
-		return 0, 0, nil, errors.New("error creating CFDictionary")
+		return nil, nil, nil, errors.New("error creating CFDictionary")
 	}
 	defer C.CFRelease(C.CFTypeRef(query))
 
 	var absResult C.CFTypeRef
 	if err := osStatusError(C.SecItemCopyMatching(query, &absResult)); err != nil {
 		if err == errSecItemNotFound {
-			return 0, 0, nil, errors.New("unable to find matching identity in cert store")
+			return nil, nil, nil, errors.New("unable to find matching identity in cert store")
 		}
-		return 0, 0, nil, err
+		return nil, nil, nil, err
 	}
 	defer C.CFRelease(C.CFTypeRef(absResult))
 	aryResult := C.CFArrayRef(absResult)
@@ -71,13 +72,14 @@ func GetMatchingCertsAndIdentity(certIdentifier CertIdentifier) (C.SecIdentityRe
 	identRefs := make([]C.CFTypeRef, numIdentRefs)
 	C.CFArrayGetValues(aryResult, C.CFRange{0, numIdentRefs}, (*unsafe.Pointer)(unsafe.Pointer(&identRefs[0])))
 	var certContainers []CertificateContainer
-	var certRef C.SecCertificateRef
-	var identRef C.SecIdentityRef
+	var certRefs []C.SecCertificateRef
+	var outputIdentRefs []C.SecIdentityRef
 	var isMatch bool
+	certContainerIndex := 0
 	for _, curIdentRef := range identRefs {
 		curCertRef, err := getCertRef(C.SecIdentityRef(curIdentRef))
 		if err != nil {
-			return 0, 0, nil, errors.New("unable to get cert ref")
+			return nil, nil, nil, errors.New("unable to get cert ref")
 		}
 		curCert, err := exportCertRef(curCertRef)
 		if err != nil {
@@ -90,14 +92,20 @@ func GetMatchingCertsAndIdentity(certIdentifier CertIdentifier) (C.SecIdentityRe
 		// Find whether there is a matching certificate
 		isMatch = certMatches(certIdentifier, *curCert)
 		if isMatch {
-			certContainers = append(certContainers, CertificateContainer{curCert, ""})
+			certContainers = append(certContainers, CertificateContainer{certContainerIndex, curCert, ""})
+			certContainerIndex += 1
 			// Assign to certRef and identRef at most once in the loop
 			// Both values are only useful if there is exactly one match in the certificate store
 			// When creating a signer, there has to be exactly one matching certificate
-			if certRef == 0 {
-				certRef = curCertRef
-				identRef = C.SecIdentityRef(curIdentRef)
-			}
+			// if certRef == 0 {
+			// 	certRef = curCertRef
+			// 	identRef = C.SecIdentityRef(curIdentRef)
+			// }
+
+			certRefs = append(certRefs, curCertRef)
+			// Note that only the SecIdentityRef needs to be retained since it was neither created nor copied
+			C.CFRetain(C.CFTypeRef(curIdentRef))
+			outputIdentRefs = append(outputIdentRefs, C.SecIdentityRef(curIdentRef))
 		}
 
 	nextIteration:
@@ -109,37 +117,74 @@ func GetMatchingCertsAndIdentity(certIdentifier CertIdentifier) (C.SecIdentityRe
 
 	// Only retain the SecIdentityRef if it should be used later on
 	// Note that only the SecIdentityRef needs to be retained since it was neither created nor copied
-	if len(certContainers) == 1 {
-		C.CFRetain(C.CFTypeRef(identRef))
-		return identRef, certRef, certContainers, nil
-	} else {
-		return 0, 0, certContainers, nil
-	}
+	// if len(certContainers) == 1 {
+	// 	C.CFRetain(C.CFTypeRef(identRef))
+	// 	return identRef, certRef, certContainers, nil
+	// } else {
+	// 	return 0, 0, certContainers, nil
+	// }
+
+	// It's the caller's responsibility to release each SecIdentityRef after use.
+	return outputIdentRefs, certRefs, certContainers, nil
 }
 
 // Gets the certificates that match the CertIdentifier
 func GetMatchingCerts(certIdentifier CertIdentifier) ([]CertificateContainer, error) {
-	identRef, certRef, certContainers, err := GetMatchingCertsAndIdentity(certIdentifier)
-	if len(certContainers) == 1 {
+	identRefs, certRefs, certContainers, err := GetMatchingCertsAndIdentity(certIdentifier)
+	for i, identRef := range identRefs {
 		C.CFRelease(C.CFTypeRef(identRef))
+		identRefs[i] = 0
+	}
+	for i, certRef := range certRefs {
 		C.CFRelease(C.CFTypeRef(certRef))
+		certRefs[i] = 0
 	}
 	return certContainers, err
 }
 
 // Creates a DarwinCertStoreSigner based on the identifying certificate
-func GetCertStoreSigner(certIdentifier CertIdentifier) (signer Signer, signingAlgorithm string, err error) {
-	identRef, certRef, certContainers, err := GetMatchingCertsAndIdentity(certIdentifier)
+func GetCertStoreSigner(certIdentifier CertIdentifier, useLatestExpiringCert bool) (signer Signer, signingAlgorithm string, err error) {
+	var (
+		selectedCertContainer CertificateContainer
+		cert                  *x509.Certificate
+		identRef              C.SecIdentityRef
+		certRef               C.SecCertificateRef
+		keyRef                C.SecKeyRef
+	)
+
+	identRefs, certRefs, certContainers, err := GetMatchingCertsAndIdentity(certIdentifier)
 	if err != nil {
-		return nil, "", err
+		goto fail
 	}
 	if len(certContainers) == 0 {
-		return nil, "", errors.New("no matching identities")
+		err = errors.New("no matching identities")
+		goto fail
 	}
-	if len(certContainers) > 1 {
-		return nil, "", errors.New("multiple matching identities")
+	if useLatestExpiringCert {
+		sort.Sort(CertificateContainerList(certContainers))
+		// Release the `SecIdentityRef`s and `SecCertificateRef`s that won't be used
+		for i, certContainer := range certContainers {
+			if i != len(certContainers)-1 {
+				C.CFRelease(C.CFTypeRef(identRefs[certContainer.Index]))
+				C.CFRelease(C.CFTypeRef(certRefs[certContainer.Index]))
+
+				identRefs[certContainer.Index] = 0
+				certRefs[certContainer.Index] = 0
+			}
+		}
+	} else {
+		if len(certContainers) > 1 {
+			err = errors.New("multiple matching identities")
+			goto fail
+		}
 	}
-	cert := certContainers[0].Cert
+	selectedCertContainer = certContainers[len(certContainers)-1]
+	if Debug {
+		log.Print(fmt.Sprintf("Selected certificate: %s", DefaultCertContainerToString(selectedCertContainer)))
+	}
+	cert = selectedCertContainer.Cert
+	certRef = certRefs[selectedCertContainer.Index]
+	identRef = identRefs[selectedCertContainer.Index]
 
 	// Find the signing algorithm
 	switch cert.PublicKey.(type) {
@@ -148,15 +193,32 @@ func GetCertStoreSigner(certIdentifier CertIdentifier) (signer Signer, signingAl
 	case *rsa.PublicKey:
 		signingAlgorithm = aws4_x509_rsa_sha256
 	default:
-		return nil, "", errors.New("unsupported algorithm")
+		err = errors.New("unsupported algorithm")
+		goto fail
 	}
 
-	keyRef, err := getKeyRef(identRef)
+	keyRef, err = getKeyRef(identRef)
 	if err != nil {
-		return nil, "", errors.New("unable to get key reference")
+		err = errors.New("unable to get key reference")
+		goto fail
 	}
 
 	return &DarwinCertStoreSigner{identRef, keyRef, certRef, cert, nil}, signingAlgorithm, nil
+
+fail:
+	for i, identRef := range identRefs {
+		if identRef != 0 {
+			C.CFRelease(C.CFTypeRef(identRef))
+			identRefs[i] = 0
+		}
+	}
+	for i, certRef := range certRefs {
+		if certRef != 0 {
+			C.CFRelease(C.CFTypeRef(certRef))
+			certRefs[i] = 0
+		}
+	}
+	return nil, "", err
 }
 
 // Gets the certificate associated with this DarwinCertStoreSigner

--- a/aws_signing_helper/cert_store_signer_darwin.go
+++ b/aws_signing_helper/cert_store_signer_darwin.go
@@ -97,10 +97,6 @@ func GetMatchingCertsAndIdentity(certIdentifier CertIdentifier) ([]C.SecIdentity
 			// Assign to certRef and identRef at most once in the loop
 			// Both values are only useful if there is exactly one match in the certificate store
 			// When creating a signer, there has to be exactly one matching certificate
-			// if certRef == 0 {
-			// 	certRef = curCertRef
-			// 	identRef = C.SecIdentityRef(curIdentRef)
-			// }
 
 			certRefs = append(certRefs, curCertRef)
 			// Note that only the SecIdentityRef needs to be retained since it was neither created nor copied
@@ -114,15 +110,6 @@ func GetMatchingCertsAndIdentity(certIdentifier CertIdentifier) ([]C.SecIdentity
 	if Debug {
 		log.Printf("found %d matching identities\n", len(certContainers))
 	}
-
-	// Only retain the SecIdentityRef if it should be used later on
-	// Note that only the SecIdentityRef needs to be retained since it was neither created nor copied
-	// if len(certContainers) == 1 {
-	// 	C.CFRetain(C.CFTypeRef(identRef))
-	// 	return identRef, certRef, certContainers, nil
-	// } else {
-	// 	return 0, 0, certContainers, nil
-	// }
 
 	// It's the caller's responsibility to release each SecIdentityRef after use.
 	return outputIdentRefs, certRefs, certContainers, nil

--- a/aws_signing_helper/cert_store_signer_linux.go
+++ b/aws_signing_helper/cert_store_signer_linux.go
@@ -10,6 +10,6 @@ func GetMatchingCerts(certIdentifier CertIdentifier) ([]CertificateContainer, er
 	return nil, errors.New("unable to use cert store signer on linux")
 }
 
-func GetCertStoreSigner(certIdentifier CertIdentifier) (signer Signer, signingAlgorithm string, err error) {
+func GetCertStoreSigner(certIdentifier CertIdentifier, useLatestExpiringCert bool) (signer Signer, signingAlgorithm string, err error) {
 	return nil, "", errors.New("unable to use cert store signer on linux")
 }

--- a/aws_signing_helper/cert_store_signer_windows.go
+++ b/aws_signing_helper/cert_store_signer_windows.go
@@ -41,6 +41,7 @@ import (
 	"golang.org/x/sys/windows"
 	"io"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -260,14 +261,10 @@ func GetMatchingCerts(certIdentifier CertIdentifier) ([]CertificateContainer, er
 }
 
 // Gets a WindowsCertStoreSigner based on the CertIdentifier
-func GetCertStoreSigner(certIdentifier CertIdentifier) (signer Signer, signingAlgorithm string, err error) {
+func GetCertStoreSigner(certIdentifier CertIdentifier, useLatestExpiringCert bool) (signer Signer, signingAlgorithm string, err error) {
 	var privateKey *winPrivateKey
 	store, certCtx, certChain, certContainers, err := GetMatchingCertsAndChain(certIdentifier)
 	if err != nil {
-		goto fail
-	}
-	if len(certContainers) > 1 {
-		err = errors.New("more than one matching cert found in cert store")
 		goto fail
 	}
 	if len(certContainers) == 0 {
@@ -275,7 +272,16 @@ func GetCertStoreSigner(certIdentifier CertIdentifier) (signer Signer, signingAl
 		goto fail
 	}
 
-	signer = &WindowsCertStoreSigner{store: store, cert: certContainers[0].Cert, certCtx: certCtx, certChain: certChain}
+	if useLatestExpiringCert {
+		sort.Sort(CertificateContainerList(certContainers))
+	} else {
+		if len(certContainers) > 1 {
+			err = errors.New("multiple matching identities")
+			goto fail
+		}
+	}
+
+	signer = &WindowsCertStoreSigner{store: store, cert: certContainers[len(certContainers)-1].Cert, certCtx: certCtx, certChain: certChain}
 
 	privateKey, err = signer.(*WindowsCertStoreSigner).getPrivateKey()
 	if err != nil {

--- a/aws_signing_helper/cert_store_signer_windows.go
+++ b/aws_signing_helper/cert_store_signer_windows.go
@@ -218,18 +218,6 @@ func GetMatchingCertsAndChain(certIdentifier CertIdentifier) (store windows.Hand
 			certContainers = append(certContainers, CertificateContainer{certContainerIndex, curCert, ""})
 			certContainerIndex += 1
 
-			// Assign to certChain and certCtx at most once in the loop.
-			// The value is only useful if there is exactly one match in the certificate store.
-			// When creating a signer, there has to be exactly one matching certificate.
-			// if certChain == nil {
-			// 	certChain = x509CertChain[:]
-			// 	certCtx = chainElts[0].CertContext
-			// 	// This is required later on when creating the WindowsCertStoreSigner
-			// 	// If this method isn't being called in order to create a WindowsCertStoreSigner,
-			// 	// this return value will have to be freed explicitly.
-			// 	windows.CertDuplicateCertificateContext(certCtx)
-			// }
-
 			certChains = append(certChains, x509CertChain[:])
 			certCtx = chainElts[0].CertContext
 			// It's the responsibility of the caller to free the below once they are done using it.

--- a/aws_signing_helper/cert_store_signer_windows.go
+++ b/aws_signing_helper/cert_store_signer_windows.go
@@ -146,7 +146,7 @@ func (secStatus securityStatus) Error() string {
 // Gets the certificates that match the given CertIdentifier within the user's specified system
 // certificate store. By default, that is "MY".
 // If there is only a single matching certificate, then its chain will be returned too
-func GetMatchingCertsAndChain(certIdentifier CertIdentifier) (store windows.Handle, certCtx *windows.CertContext, certChain []*x509.Certificate, certContainers []CertificateContainer, err error) {
+func GetMatchingCertsAndChain(certIdentifier CertIdentifier) (store windows.Handle, certCtxs []*windows.CertContext, certChains [][]*x509.Certificate, certContainers []CertificateContainer, err error) {
 	storeName, err := windows.UTF16PtrFromString(certIdentifier.SystemStoreName)
 	if err != nil {
 		return 0, nil, nil, nil, errors.New("unable to UTF-16 encode personal certificate store name")
@@ -165,12 +165,14 @@ func GetMatchingCertsAndChain(certIdentifier CertIdentifier) (store windows.Hand
 		params    windows.CertChainFindByIssuerPara
 		paramsPtr unsafe.Pointer
 		chainCtx  *windows.CertChainContext = nil
+		certCtx   *windows.CertContext
 	)
 	params.Size = uint32(unsafe.Sizeof(params))
 	paramsPtr = unsafe.Pointer(&params)
 
 	var curCertCtx *windows.CertContext
 	var curCert *x509.Certificate
+	certContainerIndex := 0
 	for {
 		// Previous chainCtx should be freed here if it isn't nil
 		chainCtx, err = windows.CertFindChainInStore(store, encoding, flags, findType, paramsPtr, chainCtx)
@@ -213,19 +215,26 @@ func GetMatchingCertsAndChain(certIdentifier CertIdentifier) (store windows.Hand
 
 		curCert = x509CertChain[0]
 		if certMatches(certIdentifier, *curCert) {
-			certContainers = append(certContainers, CertificateContainer{curCert, ""})
+			certContainers = append(certContainers, CertificateContainer{certContainerIndex, curCert, ""})
+			certContainerIndex += 1
 
 			// Assign to certChain and certCtx at most once in the loop.
 			// The value is only useful if there is exactly one match in the certificate store.
 			// When creating a signer, there has to be exactly one matching certificate.
-			if certChain == nil {
-				certChain = x509CertChain[:]
-				certCtx = chainElts[0].CertContext
-				// This is required later on when creating the WindowsCertStoreSigner
-				// If this method isn't being called in order to create a WindowsCertStoreSigner,
-				// this return value will have to be freed explicitly.
-				windows.CertDuplicateCertificateContext(certCtx)
-			}
+			// if certChain == nil {
+			// 	certChain = x509CertChain[:]
+			// 	certCtx = chainElts[0].CertContext
+			// 	// This is required later on when creating the WindowsCertStoreSigner
+			// 	// If this method isn't being called in order to create a WindowsCertStoreSigner,
+			// 	// this return value will have to be freed explicitly.
+			// 	windows.CertDuplicateCertificateContext(certCtx)
+			// }
+
+			certChains = append(certChains, x509CertChain[:])
+			certCtx = chainElts[0].CertContext
+			// It's the responsibility of the caller to free the below once they are done using it.
+			windows.CertDuplicateCertificateContext(certCtx)
+			certCtxs = append(certCtxs, certCtx)
 		}
 
 	nextIteration:
@@ -235,14 +244,18 @@ func GetMatchingCertsAndChain(certIdentifier CertIdentifier) (store windows.Hand
 		log.Printf("found %d matching identities\n", len(certContainers))
 	}
 
-	return store, certCtx, certChain, certContainers, nil
+	return store, certCtxs, certChains, certContainers, nil
 
 fail:
 	if chainCtx != nil {
 		windows.CertFreeCertificateChain(chainCtx)
+		chainCtx = nil
 	}
-	if certCtx != nil {
-		windows.CertFreeCertificateContext(certCtx)
+	for i, curCertCtx := range certCtxs {
+		if curCertCtx != nil {
+			windows.CertFreeCertificateContext(curCertCtx)
+			certCtxs[i] = nil
+		}
 	}
 	windows.CertCloseStore(store, 0)
 
@@ -251,9 +264,12 @@ fail:
 
 // Gets the certificates that match a CertIdentifier
 func GetMatchingCerts(certIdentifier CertIdentifier) ([]CertificateContainer, error) {
-	store, certCtx, _, certContainers, err := GetMatchingCertsAndChain(certIdentifier)
-	if certCtx != nil {
-		windows.CertFreeCertificateContext(certCtx)
+	store, certCtxs, _, certContainers, err := GetMatchingCertsAndChain(certIdentifier)
+	for i, curCertCtx := range certCtxs {
+		if curCertCtx != nil {
+			windows.CertFreeCertificateContext(curCertCtx)
+			certCtxs[i] = nil
+		}
 	}
 	windows.CertCloseStore(store, 0)
 
@@ -262,8 +278,15 @@ func GetMatchingCerts(certIdentifier CertIdentifier) ([]CertificateContainer, er
 
 // Gets a WindowsCertStoreSigner based on the CertIdentifier
 func GetCertStoreSigner(certIdentifier CertIdentifier, useLatestExpiringCert bool) (signer Signer, signingAlgorithm string, err error) {
-	var privateKey *winPrivateKey
-	store, certCtx, certChain, certContainers, err := GetMatchingCertsAndChain(certIdentifier)
+	var (
+		privateKey            *winPrivateKey
+		selectedCertContainer CertificateContainer
+		cert                  *x509.Certificate
+		certCtx               *windows.CertContext
+		certChain             []*x509.Certificate
+	)
+
+	store, certCtxs, certChains, certContainers, err := GetMatchingCertsAndChain(certIdentifier)
 	if err != nil {
 		goto fail
 	}
@@ -281,7 +304,15 @@ func GetCertStoreSigner(certIdentifier CertIdentifier, useLatestExpiringCert boo
 		}
 	}
 
-	signer = &WindowsCertStoreSigner{store: store, cert: certContainers[len(certContainers)-1].Cert, certCtx: certCtx, certChain: certChain}
+	selectedCertContainer = certContainers[len(certContainers)-1]
+	if Debug {
+		log.Printf("selected certificate: %s", DefaultCertContainerToString(selectedCertContainer))
+	}
+	cert = selectedCertContainer.Cert
+	certCtx = certCtxs[selectedCertContainer.Index]
+	certChain = certChains[selectedCertContainer.Index]
+
+	signer = &WindowsCertStoreSigner{store: store, cert: cert, certCtx: certCtx, certChain: certChain}
 
 	privateKey, err = signer.(*WindowsCertStoreSigner).getPrivateKey()
 	if err != nil {
@@ -302,8 +333,11 @@ func GetCertStoreSigner(certIdentifier CertIdentifier, useLatestExpiringCert boo
 	return signer, signingAlgorithm, err
 
 fail:
-	if certCtx != nil {
-		windows.CertFreeCertificateContext(certCtx)
+	for i, curCertCtx := range certCtxs {
+		if curCertCtx != nil {
+			windows.CertFreeCertificateContext(curCertCtx)
+			certCtxs[i] = nil
+		}
 	}
 	if signer != nil {
 		signer.Close()

--- a/aws_signing_helper/credentials.go
+++ b/aws_signing_helper/credentials.go
@@ -19,26 +19,27 @@ import (
 )
 
 type CredentialsOpts struct {
-	PrivateKeyId        string
-	CertificateId       string
-	CertificateBundleId string
-	CertIdentifier      CertIdentifier
-	RoleArn             string
-	ProfileArnStr       string
-	TrustAnchorArnStr   string
-	SessionDuration     int
-	Region              string
-	Endpoint            string
-	NoVerifySSL         bool
-	WithProxy           bool
-	Debug               bool
-	Version             string
-	LibPkcs11           string
-	ReusePin            bool
-	TpmKeyPassword      string
-	NoTpmKeyPassword    bool
-	ServerTTL           int
-	RoleSessionName     string
+	PrivateKeyId                 string
+	CertificateId                string
+	CertificateBundleId          string
+	CertIdentifier               CertIdentifier
+	UseLatestExpiringCertificate bool
+	RoleArn                      string
+	ProfileArnStr                string
+	TrustAnchorArnStr            string
+	SessionDuration              int
+	Region                       string
+	Endpoint                     string
+	NoVerifySSL                  bool
+	WithProxy                    bool
+	Debug                        bool
+	Version                      string
+	LibPkcs11                    string
+	ReusePin                     bool
+	TpmKeyPassword               string
+	NoTpmKeyPassword             bool
+	ServerTTL                    int
+	RoleSessionName              string
 }
 
 // Middleware to set a custom user agent header

--- a/aws_signing_helper/pkcs11_signer.go
+++ b/aws_signing_helper/pkcs11_signer.go
@@ -482,7 +482,7 @@ func GetMatchingPKCSCerts(uriStr string, lib string) (matchingCerts []Certificat
 		if err != nil {
 			curUriStr = ""
 		}
-		matchingCerts = append(matchingCerts, CertificateContainer{obj.cert, curUriStr})
+		matchingCerts = append(matchingCerts, CertificateContainer{-1, obj.cert, curUriStr})
 	}
 
 	// Note that this clean up should happen regardless of failure.

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -21,16 +21,18 @@ var (
 	noVerifySSL       bool
 	withProxy         bool
 	debug             bool
-	reusePin          bool
 	roleSessionName   string
 
 	certificateId       string
 	privateKeyId        string
 	certificateBundleId string
-	certSelector        string
-	systemStoreName     string
+
+	certSelector                 string
+	systemStoreName              string
+	useLatestExpiringCertificate bool
 
 	libPkcs11 string
+	reusePin  bool
 
 	tpmKeyPassword   string
 	noTpmKeyPassword bool
@@ -72,6 +74,9 @@ func initCredentialsSubCommand(subCmd *cobra.Command) {
 		"Can be passed in either as string or a file name (prefixed by \"file://\")")
 	subCmd.PersistentFlags().StringVar(&systemStoreName, "system-store-name", "MY", "Name of the system store to search for within the "+
 		"CERT_SYSTEM_STORE_CURRENT_USER context. Note that this flag is only relevant for Windows certificate stores and will be ignored otherwise")
+	subCmd.PersistentFlags().BoolVar(&useLatestExpiringCertificate, "use-latest-expiring-certificate", false, "If multiple certificates match "+
+		"a given certificate selector, the one that expires the latest will be chosen (if more than one still fits this criteria, an arbitrary "+
+		"one is chosen from those that meet the criteria)")
 	subCmd.PersistentFlags().StringVar(&libPkcs11, "pkcs11-lib", "", "Library for smart card / cryptographic device (OpenSC or vendor specific)")
 	subCmd.PersistentFlags().BoolVar(&reusePin, "reuse-pin", false, "Use the CKU_USER PIN as the CKU_CONTEXT_SPECIFIC PIN for "+
 		"private key objects, when they are first used to sign. If the CKU_USER PIN doesn't work as the CKU_CONTEXT_SPECIFIC PIN "+
@@ -85,6 +90,9 @@ func initCredentialsSubCommand(subCmd *cobra.Command) {
 	subCmd.MarkFlagsMutuallyExclusive("certificate", "system-store-name")
 	subCmd.MarkFlagsMutuallyExclusive("private-key", "cert-selector")
 	subCmd.MarkFlagsMutuallyExclusive("private-key", "system-store-name")
+	subCmd.MarkFlagsMutuallyExclusive("private-key", "use-latest-expiring-certificate")
+	subCmd.MarkFlagsMutuallyExclusive("use-latest-expiring-certificate", "intermediates")
+	subCmd.MarkFlagsMutuallyExclusive("use-latest-expiring-certificate", "reuse-pin")
 	subCmd.MarkFlagsMutuallyExclusive("cert-selector", "intermediates")
 	subCmd.MarkFlagsMutuallyExclusive("cert-selector", "reuse-pin")
 	subCmd.MarkFlagsMutuallyExclusive("system-store-name", "reuse-pin")
@@ -238,25 +246,26 @@ func PopulateCredentialsOptions() error {
 	}
 
 	credentialsOptions = helper.CredentialsOpts{
-		PrivateKeyId:        privateKeyId,
-		CertificateId:       certificateId,
-		CertificateBundleId: certificateBundleId,
-		CertIdentifier:      certIdentifier,
-		RoleArn:             roleArnStr,
-		ProfileArnStr:       profileArnStr,
-		TrustAnchorArnStr:   trustAnchorArnStr,
-		SessionDuration:     sessionDuration,
-		Region:              region,
-		Endpoint:            endpoint,
-		NoVerifySSL:         noVerifySSL,
-		WithProxy:           withProxy,
-		Debug:               debug,
-		Version:             Version,
-		LibPkcs11:           libPkcs11,
-		ReusePin:            reusePin,
-		TpmKeyPassword:      tpmKeyPassword,
-		NoTpmKeyPassword:    noTpmKeyPassword,
-		RoleSessionName:     roleSessionName,
+		PrivateKeyId:                 privateKeyId,
+		CertificateId:                certificateId,
+		CertificateBundleId:          certificateBundleId,
+		CertIdentifier:               certIdentifier,
+		UseLatestExpiringCertificate: useLatestExpiringCertificate,
+		RoleArn:                      roleArnStr,
+		ProfileArnStr:                profileArnStr,
+		TrustAnchorArnStr:            trustAnchorArnStr,
+		SessionDuration:              sessionDuration,
+		Region:                       region,
+		Endpoint:                     endpoint,
+		NoVerifySSL:                  noVerifySSL,
+		WithProxy:                    withProxy,
+		Debug:                        debug,
+		Version:                      Version,
+		LibPkcs11:                    libPkcs11,
+		ReusePin:                     reusePin,
+		TpmKeyPassword:               tpmKeyPassword,
+		NoTpmKeyPassword:             noTpmKeyPassword,
+		RoleSessionName:              roleSessionName,
 	}
 
 	return nil

--- a/cmd/read_certificate_data.go
+++ b/cmd/read_certificate_data.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -29,17 +27,9 @@ func init() {
 
 type PrintCertificate func(int, helper.CertificateContainer)
 
+// Default function for printing certificate information
 func DefaultPrintCertificate(index int, certContainer helper.CertificateContainer) {
-	cert := certContainer.Cert
-
-	fingerprint := sha1.Sum(cert.Raw) // nosemgrep
-	fingerprintHex := hex.EncodeToString(fingerprint[:])
-	fmt.Printf("%d) %s \"%s\"\n", index+1, fingerprintHex, cert.Subject.String())
-
-	// Only for PKCS#11
-	if certContainer.Uri != "" {
-		fmt.Printf("\tURI: %s\n", certContainer.Uri)
-	}
+	fmt.Printf("%d) %s", index+1, helper.DefaultCertContainerToString(certContainer))
 }
 
 var readCertificateDataCmd = &cobra.Command{

--- a/cmd/sign_string.go
+++ b/cmd/sign_string.go
@@ -80,6 +80,9 @@ func init() {
 		"Can be passed in either as string or a file name (prefixed by \"file://\")")
 	signStringCmd.PersistentFlags().StringVar(&systemStoreName, "system-store-name", "MY", "Name of the system store to search for within the "+
 		"CERT_SYSTEM_STORE_CURRENT_USER context. Note that this flag is only relevant for Windows certificate stores and will be ignored otherwise")
+	signStringCmd.PersistentFlags().BoolVar(&useLatestExpiringCertificate, "use-latest-expiring-certificate", false, "If multiple certificates match "+
+		"a given certificate selector, the one that expires the latest will be chosen (if more than one still fits this criteria, an arbitrary "+
+		"one is chosen from those that meet the criteria)")
 	signStringCmd.PersistentFlags().StringVar(&libPkcs11, "pkcs11-lib", "", "Library for smart card / cryptographic device (default: p11-kit-proxy.{so, dll, dylib})")
 	signStringCmd.PersistentFlags().BoolVar(&reusePin, "reuse-pin", false, "Use the CKU_USER PIN as the CKU_CONTEXT_SPECIFIC PIN for "+
 		"private key objects, when they are first used to sign. If the CKU_USER PIN doesn't work as the CKU_CONTEXT_SPECIFIC PIN "+
@@ -94,6 +97,8 @@ func init() {
 	signStringCmd.MarkFlagsMutuallyExclusive("certificate", "system-store-name")
 	signStringCmd.MarkFlagsMutuallyExclusive("private-key", "cert-selector")
 	signStringCmd.MarkFlagsMutuallyExclusive("private-key", "system-store-name")
+	signStringCmd.MarkFlagsMutuallyExclusive("private-key", "use-latest-expiring-certificate")
+	signStringCmd.MarkFlagsMutuallyExclusive("use-latest-expiring-certificate", "reuse-pin")
 	signStringCmd.MarkFlagsMutuallyExclusive("cert-selector", "reuse-pin")
 	signStringCmd.MarkFlagsMutuallyExclusive("system-store-name", "reuse-pin")
 	signStringCmd.MarkFlagsMutuallyExclusive("tpm-key-password", "cert-selector")


### PR DESCRIPTION
*Description of changes:*

Introduce `--use-latest-expiring-certificate` flag to select latest expiring certificate when multiple certificates match a given selector but only one of them should be selected. Tested happy-path through `sign-string` on both Darwin and Windows. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
