### PR TITLE
Fixes related to Go v2 SDK migration

### DIFF
--- a/aws_signing_helper/credentials.go
+++ b/aws_signing_helper/credentials.go
@@ -122,18 +122,12 @@ func GenerateCredentials(opts *CredentialsOpts, signer Signer, signatureAlgorith
 		}
 	}
 	cfg.APIOptions = append(cfg.APIOptions, func(stack *middleware.Stack) error {
-		for _, name := range stack.Finalize.List() {
-			fmt.Println(name)
-		}
 		// Remove middleware related to SigV4 signing
 		stack.Finalize.Remove("Signing")
 		stack.Finalize.Remove("setLegacyContextSigningOptions")
 		stack.Finalize.Remove("GetIdentity")
 		// Add middleware for SigV4-X509 signing
 		stack.Finalize.Add(middleware.FinalizeMiddlewareFunc("Signing", CreateRequestSignFinalizeFunction(signer, opts.Region, signatureAlgorithm, certificate, certificateChain)), middleware.After)
-		for _, name := range stack.Finalize.List() {
-			fmt.Println(name)
-		}
 		return nil
 	})
 

--- a/aws_signing_helper/serve.go
+++ b/aws_signing_helper/serve.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 )
 
 const DefaultPort = 9911

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/aws/rolesanywhere-credential-helper
 go 1.22.5
 
 require (
-	github.com/aws/aws-sdk-go v1.55.5
 	github.com/aws/aws-sdk-go-v2 v1.36.1
 	github.com/aws/aws-sdk-go-v2/config v1.29.6
 	github.com/aws/smithy-go v1.22.2

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
-github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.1 h1:iTDl5U6oAhkNPba0e1t1hrwAo02ZMqbrGq4k5JBWM5E=
 github.com/aws/aws-sdk-go-v2 v1.36.1/go.mod h1:5PMILGVKiW32oDzjj6RU52yrNrDPUHcbZQYr1sM7qmM=
 github.com/aws/aws-sdk-go-v2/config v1.29.6 h1:fqgqEKK5HaZVWLQoLiC9Q+xDlSp+1LYidp6ybGE2OGg=


### PR DESCRIPTION
* Remove unnecessary debug output from credentialing commands
* Remove the last instance of using the Go v1 SDK (for ARN parsing)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
