### PR TITLE
fix: switch TTY open order (resolves bug if theres no TTY)

### DIFF
--- a/aws_signing_helper/signer.go
+++ b/aws_signing_helper/signer.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"golang.org/x/crypto/pkcs12"
@@ -195,18 +195,6 @@ func PasswordPrompt(passwordPromptInput PasswordPromptProps) (string, interface{
 		ttyWritePath = "CONOUT$"
 	}
 
-	ttyReadFile, err = os.OpenFile(ttyReadPath, os.O_RDWR, 0)
-	if err != nil {
-		return "", nil, errors.New(parseErrMsg)
-	}
-	defer ttyReadFile.Close()
-
-	ttyWriteFile, err = os.OpenFile(ttyWritePath, os.O_WRONLY, 0)
-	if err != nil {
-		return "", nil, errors.New(parseErrMsg)
-	}
-	defer ttyWriteFile.Close()
-
 	// If no password is required
 	if noPassword {
 		checkPasswordResult, err = checkPassword("")
@@ -224,6 +212,18 @@ func PasswordPrompt(passwordPromptInput PasswordPromptProps) (string, interface{
 		}
 		return password, checkPasswordResult, nil
 	}
+
+	ttyReadFile, err = os.OpenFile(ttyReadPath, os.O_RDWR, 0)
+	if err != nil {
+		return "", nil, errors.New(parseErrMsg)
+	}
+	defer ttyReadFile.Close()
+
+	ttyWriteFile, err = os.OpenFile(ttyWritePath, os.O_WRONLY, 0)
+	if err != nil {
+		return "", nil, errors.New(parseErrMsg)
+	}
+	defer ttyWriteFile.Close()
 
 	// The key has a password, so prompt for it
 	password, err = GetPassword(ttyReadFile, ttyWriteFile, prompt, parseErrMsg)


### PR DESCRIPTION
When running the credential helper in cloud-init, there is no TTY available. I discovered that the credential-helper fails at the moment because there's no `/dev/tty` available in this setting, **even though I am using `--no-tpm-password` and not using the TTY**.

This PR resolves the issue, by moving the TTY logic down a few lines, so that it only gets opened right before it is actually used (and it isn't reached in the no-password case)