### PR TITLE
Support password-protected private keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ You can pass a password-encrypted private key to the credential helper for signi
 - Unencrypted: `-----BEGIN PRIVATE KEY-----`
 - Password-encrypted: `-----BEGIN ENCRYPTED PRIVATE KEY-----` (using PBES2)
 
-To encrypt an unencrypted private key stored on disk, use a tool of your choice. The following example uses OpenSSL in a Bash environment:
+To encrypt a plaintext private key stored on disk, you can use `openssl`:
 
 ```bash
 openssl pkcs8 -topk8 -in unencrypted-key.pem -out encrypted-key.pem -passout pass:password -v2 aes-256-cbc
@@ -220,7 +220,7 @@ This command encrypts a PEM file containing an unencrypted private key in PKCS#8
 - AES-192-CBC
 - AES-256-CBC
 
-You can also encrypt the key using a different Pseudorandom Function (PRF):
+You can also encrypt the key using a different pseudorandom function (PRF):
 
 ```bash
 openssl pkcs8 -topk8 -in unencrypted-key.pem -out encrypted-key.pem -passout pass:password -v2prf hmacWithSHA256
@@ -234,7 +234,7 @@ Supported PRFs include:
 
 If you don't specify a cipher or PRF, the key is converted to PKCS#8 format using PKCS#5 v2.0 with AES-256-CBC and HMACWithSHA256.
 The credential helper supports decrypting PKCS#8-encrypted private keys using PBES2, as defined in PKCS#5 (RFC 8018), with the options mentioned earlier. The key derivation function is PBKDF2, as specified in RFC 8018.
-To enhance key protection, you can use scrypt to secure the PKCS#8-encoded key. Scrypt, defined in RFC 7914, is a memory-intensive algorithm that improves resistance to attacks.
+To enhance key protection, you can use scrypt to secure the PKCS#8-encoded key. Scrypt, defined in RFC 7914, is a memory-intensive KDF that improves resistance to attacks.
 To encrypt a key using scrypt with OpenSSL:
 
 ```bash
@@ -246,6 +246,7 @@ After obtaining the encrypted key in a PEM file, pass it to the credential helpe
 
 - If you don't want to encrypt a private key and are using OpenSSL, use the `-nocrypt` flag.
 - Zero-length passwords are treated as no password.
+- Only UTF-8-encoded passwords are supported.
 
 ##### Testing
 Currently, unit tests for testing TPM support are written in such a way that TPM keys that are used 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ openssl pkcs8 -topk8 -in unencrypted-key.pem -out encrypted-key.pem -passout pas
 This command uses the default scrypt parameters: N=16,384, r=8, and p=1.
 After obtaining the encrypted key in a PEM file, pass it to the credential helper along with the password as the value for the `--pkcs8-password` option during signing. Note the following:
 
-- Zero-length passwords aren't accepted.
 - If you don't want to encrypt a private key and are using OpenSSL, use the `-nocrypt` flag.
 - Zero-length passwords are treated as no password.
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,51 @@ the signing key (the loading process will have to be done with other tools and w
 you to provivde your parent key password) into the TPM and referencing its handle in the command 
 you want to call with the credential helper. 
 
+#### Password-Encrypted Private Keys
+You can pass a password-encrypted private key to the credential helper for signing the request. The credential helper supports two formats of PKCS#8 private key files:
+- Unencrypted: `-----BEGIN PRIVATE KEY-----`
+- Password-encrypted: `-----BEGIN ENCRYPTED PRIVATE KEY-----` (using PBES2)
+
+To encrypt an unencrypted private key stored on disk, use a tool of your choice. The following example uses OpenSSL in a Bash environment:
+
+```bash
+openssl pkcs8 -topk8 -in unencrypted-key.pem -out encrypted-key.pem -passout pass:password -v2 aes-256-cbc
+```
+
+This command encrypts a PEM file containing an unencrypted private key in PKCS#8 format using the AES-256-CBC cipher with the password "password". The encrypted key is saved to a PEM file. Supported ciphers include:
+
+- AES-128-CBC
+- AES-192-CBC
+- AES-256-CBC
+
+You can also encrypt the key using a different Pseudorandom Function (PRF):
+
+```bash
+openssl pkcs8 -topk8 -in unencrypted-key.pem -out encrypted-key.pem -passout pass:password -v2prf hmacWithSHA256
+```
+
+Supported PRFs include:
+
+- HMACWithSHA256
+- HMACWithSHA384
+- HMACWithSHA512
+
+If you don't specify a cipher or PRF, the key is converted to PKCS#8 format using PKCS#5 v2.0 with AES-256-CBC and HMACWithSHA256.
+The credential helper supports decrypting PKCS#8-encrypted private keys using PBES2, as defined in PKCS#5 (RFC 8018), with the options mentioned earlier. The key derivation function is PBKDF2, as specified in RFC 8018.
+To enhance key protection, you can use scrypt to secure the PKCS#8-encoded key. Scrypt, defined in RFC 7914, is a memory-intensive algorithm that improves resistance to attacks.
+To encrypt a key using scrypt with OpenSSL:
+
+```bash
+openssl pkcs8 -topk8 -in unencrypted-key.pem -out encrypted-key.pem -passout pass:password -scrypt
+```
+
+This command uses the default scrypt parameters: N=16,384, r=8, and p=1.
+After obtaining the encrypted key in a PEM file, pass it to the credential helper along with the password as the value for the `--pkcs8-password` option during signing. Note the following:
+
+- Zero-length passwords aren't accepted.
+- If you don't want to encrypt a private key and are using OpenSSL, use the `-nocrypt` flag.
+- Zero-length passwords are treated as no password.
+
 ##### Testing
 Currently, unit tests for testing TPM support are written in such a way that TPM keys that are used 
 for testing are either bound to a hardware TPM, or are bound to a software TPM. For software TPM 

--- a/aws_signing_helper/credentials.go
+++ b/aws_signing_helper/credentials.go
@@ -40,6 +40,7 @@ type CredentialsOpts struct {
 	NoTpmKeyPassword             bool
 	ServerTTL                    int
 	RoleSessionName              string
+	Pkcs8Password                string
 }
 
 // Middleware to set a custom user agent header

--- a/aws_signing_helper/file_system_signer.go
+++ b/aws_signing_helper/file_system_signer.go
@@ -112,38 +112,38 @@ func (fileSystemSigner *FileSystemSigner) readCertFiles() (crypto.PrivateKey, *x
 	if fileSystemSigner.isPkcs12 {
 		chain, privateKey, err := ReadPKCS12Data(fileSystemSigner.certPath)
 		if err != nil {
-			log.Printf("Failed to read PKCS12 certificate: %s\n", err)
+			log.Printf("failed to read PKCS12 certificate: %s\n", err)
 			os.Exit(1)
 		}
 		return privateKey, chain[0], chain
 	} else {
 		var privateKey crypto.PrivateKey
 		var err error
-		if (len(fileSystemSigner.pkcs8Password) > 0 && fileSystemSigner.pkcs8Password != "") || isPKCS8EncryptedPrivateKey(fileSystemSigner.privateKeyPath, EncryptedBlockType) {
+		if len(fileSystemSigner.pkcs8Password) > 0 || isPKCS8EncryptedBlockType(fileSystemSigner.privateKeyPath) {
 			passwordPromptInput := PasswordPromptProps{
 				InitialPassword: fileSystemSigner.pkcs8Password,
 				NoPassword:      false,
 				CheckPassword: func(password string) (interface{}, error) {
 					return ReadPrivateKeyData(fileSystemSigner.privateKeyPath, password)
 				},
-				IncorrectPasswordMsg:               "incorrect PKCS8 private key password",
+				IncorrectPasswordMsg:               "incorrect PKCS#8 private key password",
 				Prompt:                             "Please enter your PKC8 private key password:",
-				Reprompt:                           "Incorrect PKCS8 private key password. Please try again:",
-				ParseErrMsg:                        "unable to read your PKCS8 private key password",
+				Reprompt:                           "Incorrect PKCS#8 private key password. Please try again:",
+				ParseErrMsg:                        "unable to read your PKCS#8 private key password",
 				CheckPasswordAuthorizationErrorMsg: "unable to parse private key",
 			}
-			password, sig, err := PasswordPrompt(passwordPromptInput)
+			password, signingPrivKey, err := PasswordPrompt(passwordPromptInput)
 			if err != nil {
-				log.Printf("Failed to read private key: %s\n", err)
+				log.Printf("failed to read private key: %s\n", err)
 				os.Exit(1)
 			}
 
 			fileSystemSigner.pkcs8Password = password
-			privateKey, _ = sig.(crypto.PrivateKey)
+			privateKey, _ = signingPrivKey.(crypto.PrivateKey)
 		} else {
-			privateKey, err = ReadPrivateKeyData(fileSystemSigner.privateKeyPath, fileSystemSigner.pkcs8Password)
+			privateKey, err = ReadPrivateKeyData(fileSystemSigner.privateKeyPath, "")
 			if err != nil {
-				log.Printf("Failed to read private key: %s\n", err)
+				log.Printf("failed to read private key: %s\n", err)
 				os.Exit(1)
 			}
 		}
@@ -153,7 +153,7 @@ func (fileSystemSigner *FileSystemSigner) readCertFiles() (crypto.PrivateKey, *x
 			chain, err = GetCertChain(fileSystemSigner.bundlePath)
 			if err != nil {
 				privateKey = nil
-				log.Printf("Failed to read certificate bundle: %s\n", err)
+				log.Printf("failed to read certificate bundle: %s\n", err)
 				os.Exit(1)
 			}
 		}
@@ -162,7 +162,7 @@ func (fileSystemSigner *FileSystemSigner) readCertFiles() (crypto.PrivateKey, *x
 			_, cert, err = ReadCertificateData(fileSystemSigner.certPath)
 			if err != nil {
 				privateKey = nil
-				log.Printf("Failed to read certificate: %s\n", err)
+				log.Printf("failed to read certificate: %s\n", err)
 				os.Exit(1)
 			}
 		} else if len(chain) > 0 {

--- a/aws_signing_helper/pkcs8_utils.go
+++ b/aws_signing_helper/pkcs8_utils.go
@@ -1,0 +1,309 @@
+package aws_signing_helper
+
+// PKCS#8 is a cryptographic standard that defines a flexible format
+// for encoding private key information, including both the key data
+// and optional attributes such as encryption parameters. It also allows
+// private keys to be encrypted using password-based encryption methods,
+// providing an additional layer of security.
+//
+// This file contains implementations of PKCS#8 decryption, which decodes
+// a PKCS#8-encrypted private key using PBES2, as defined in PKCS #5 (RFC 8018).
+//
+// Not all ciphers or pseudo-random function(PRF) are supported. Please refer to the list below for the supported options.
+//
+// Supported ciphers: AES-128/192/256-CBC
+// Supported KDFs: PBKDF2, Scrypt
+// Supported PRFs: HMACWithSHA256, HMACWithSHA384, HMACWithSHA512
+
+import (
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+
+	"errors"
+	"fmt"
+	"hash"
+	"log"
+	"os"
+
+	"golang.org/x/crypto/pbkdf2"
+	"golang.org/x/crypto/scrypt"
+)
+
+// as defined in https://datatracker.ietf.org/doc/html/rfc8018#appendix-A.4
+type PBES2Params struct {
+	KeyDerivationFunc pkix.AlgorithmIdentifier
+	EncryptionScheme  pkix.AlgorithmIdentifier
+}
+
+// as defined in https://datatracker.ietf.org/doc/html/rfc5958#section-3
+type EncryptedPrivateKeyInfo struct {
+	EncryptionAlgorithm pkix.AlgorithmIdentifier
+	EncryptedData       []byte
+}
+
+// as defined in https://datatracker.ietf.org/doc/html/rfc8018#appendix-A.2
+type PBKDF2RPFParams struct {
+	Algorithm asn1.ObjectIdentifier
+	Params    asn1.RawValue `asn1:"optional"`
+}
+
+// as defined in https://datatracker.ietf.org/doc/html/rfc8018#appendix-A.2
+// and https://datatracker.ietf.org/doc/html/rfc8018#section-5.2
+type PBKDF2Params struct {
+	Salt      []byte
+	Iteration int
+	PRF       PBKDF2RPFParams
+}
+
+type ScryptParams struct {
+	Salt                  []byte
+	CostFactor            int
+	BlockSizeFactor       int
+	ParallelizationFactor int
+}
+
+// Supported PRFs
+var (
+	oidHMACWithSHA256 = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 9}
+	oidHMACWithSHA384 = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 10}
+	oidHMACWithSHA512 = asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 11}
+)
+
+// Supported KDFs
+var (
+	oidPBKDF2 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 12}
+	oidScrypt = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11591, 4, 11}
+)
+
+// Supported Ciphers
+var cipherMap = map[string]struct {
+	KeySize   int
+	NewCipher func([]byte) (cipher.Block, error)
+}{
+	"2.16.840.1.101.3.4.1.42": {32, aes.NewCipher}, // AES-256-CBC
+	"2.16.840.1.101.3.4.1.22": {24, aes.NewCipher}, // AES-192-CBC
+	"2.16.840.1.101.3.4.1.2":  {16, aes.NewCipher}, // AES-128-CBC
+}
+
+const UnencryptedBlockType = "PRIVATE KEY"
+const EncryptedBlockType = "ENCRYPTED PRIVATE KEY"
+
+// 'getNewHash' creates a new hash based on the specified PRF
+func getNewHash(oid asn1.ObjectIdentifier) (func() hash.Hash, error) {
+	switch {
+	case oid.Equal(oidHMACWithSHA256):
+		return sha256.New, nil
+	case oid.Equal(oidHMACWithSHA384):
+		return sha512.New384, nil
+	case oid.Equal(oidHMACWithSHA512):
+		return sha512.New, nil
+	default:
+		return nil, errors.New("unsupported hash function")
+	}
+}
+
+// 'extractCipherParams' extracts and parses cipher parameters.
+// It identifies the encryption algorithm and returns the IV and key size based on the detected algorithm.
+func extractCipherParams(es pkix.AlgorithmIdentifier) ([]byte, int, error) {
+	algo, exist := cipherMap[es.Algorithm.String()]
+	if !exist {
+		return nil, 0, errors.New("unsupported encryption algorithm")
+	}
+
+	var iv []byte
+	if _, err := asn1.Unmarshal(es.Parameters.FullBytes, &iv); err != nil {
+		return nil, 0, errors.New("failed to parse the initialization vector")
+	}
+	return iv, algo.KeySize, nil
+}
+
+// PBKDF2 is a cryptographic algorithm designed to derive strong cryptographic keys from weak passwords by
+// applying a hashing function iteratively.
+// It takes as input a password, a cryptographic salt, an iteration count, and a desired output key length.
+// PBKDF2 is formally specified in RFC 8018, which is part of the PKCS#5 standard.
+func deriveKeyUsingPBKDF2(parameterBytes []byte, keySize int, password []byte) ([]byte, error) {
+	var kdfParams PBKDF2Params
+	if _, err := asn1.Unmarshal(parameterBytes, &kdfParams); err != nil {
+		return nil, fmt.Errorf("failed to parse ASN.1 OID: %w", err)
+	}
+
+	hashFunc, err := getNewHash(kdfParams.PRF.Algorithm)
+	if err != nil {
+		return nil, err
+	}
+	key := pbkdf2.Key(password, kdfParams.Salt, kdfParams.Iteration, keySize, hashFunc)
+	return key, nil
+}
+
+// Scrypt is a password-based key derivation function specifically designed to be computationally and memory-hard.
+// The algorithm was specifically designed to make it costly to perform large-scale custom hardware attacks by requiring large amounts of memory.
+// For more information about Scrypt:
+// https://en.wikipedia.org/wiki/Scrypt
+func deriveKeyUsingScrypt(parameterBytes []byte, keySize int, password []byte) ([]byte, error) {
+	var kdfParams ScryptParams
+	if _, err := asn1.Unmarshal(parameterBytes, &kdfParams); err != nil {
+		return nil, fmt.Errorf("failed to parse ASN.1 OID: %w", err)
+	}
+
+	key, err := scrypt.Key(password, kdfParams.Salt, kdfParams.CostFactor, kdfParams.BlockSizeFactor,
+		kdfParams.ParallelizationFactor, keySize)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// 'parseDERFromPEMForPKCS8' parses a PEM file.
+// If the blockType matches the required PEM blockType, it returns the decoded bytes.
+// It is only called for verifying PKCS#8 private keys. If the blockType is "PRIVATE KEY",
+// it indicates that a PKCS#8 password was provided when it should not have been.
+// Conversely, if the bloclType is "ENCRYPTED PRIVATE KEY",
+// it means the password was not provided when required.
+func parseDERFromPEMForPKCS8(pemDataId string, blockType string) (*pem.Block, error) {
+	bytes, err := os.ReadFile(pemDataId)
+	if err != nil {
+		return nil, err
+	}
+
+	var block *pem.Block
+	for len(bytes) > 0 {
+		block, bytes = pem.Decode(bytes)
+		if block == nil {
+			return nil, errors.New("unable to parse PEM data")
+		}
+		if block.Type == blockType {
+			return block, nil
+		}
+		if block.Type == UnencryptedBlockType {
+			if Debug {
+				log.Println("PKCS#8 password provided but block type indicates that one isn't required.")
+			}
+			return nil, errors.New("PKCS#8 password provided but block type indicates that one isn't required")
+		}
+	}
+	return nil, errors.New("requested block type could not be found")
+}
+
+// 'isPKCS8EncryptedPrivateKey' tries to decode the PEM block
+// and determine if the private key is PKCS8-encrypted based on the PEM block type.
+func isPKCS8EncryptedPrivateKey(pemDataId string, blockType string) bool {
+	bytes, err := os.ReadFile(pemDataId)
+	if err != nil {
+		return false
+	}
+
+	var block *pem.Block
+	for len(bytes) > 0 {
+		block, bytes = pem.Decode(bytes)
+		if block == nil {
+			return false
+		}
+		if block.Type == blockType {
+			return true
+		}
+	}
+	return false
+}
+
+// 'readPKCS8PrivateKey' reads and parses an unencrypted PKCS#8 private key.
+func readPKCS8PrivateKey(privateKeyId string) (crypto.PrivateKey, error) {
+	block, err := parseDERFromPEMForPKCS8(privateKeyId, UnencryptedBlockType)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, errors.New("could not parse private key")
+	}
+
+	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
+	if ok {
+		return rsaPrivateKey, nil
+	}
+
+	ecPrivateKey, ok := privateKey.(*ecdsa.PrivateKey)
+	if ok {
+		return ecPrivateKey, nil
+	}
+
+	return nil, errors.New("could not parse PKCS#8 private key")
+}
+
+// 'readPKCS8EncryptedPrivateKey' reads and parses an encrypted PKCS#8 private key, following the process defined in RFC 8018.
+// Note that the encryption scheme must be PBES2, and the supported key types are limited to RSA and ECDSA.
+func readPKCS8EncryptedPrivateKey(privateKeyId string, pkcs8Password []byte) (crypto.PrivateKey, error) {
+	block, err := parseDERFromPEMForPKCS8(privateKeyId, EncryptedBlockType)
+	if err != nil {
+		return nil, errors.New("could not parse PEM data")
+	}
+
+	var privKey EncryptedPrivateKeyInfo
+	if _, err := asn1.Unmarshal(block.Bytes, &privKey); err != nil {
+		return nil, fmt.Errorf("failed to parse PKCS#8 structure: %w", err)
+	}
+
+	var pbes2 PBES2Params
+	if _, err := asn1.Unmarshal(privKey.EncryptionAlgorithm.Parameters.FullBytes, &pbes2); err != nil {
+		return nil, errors.New("invalid PBES2 parameters")
+	}
+
+	iv, keySize, err := extractCipherParams(pbes2.EncryptionScheme)
+	if err != nil {
+		return nil, err
+	}
+
+	kdfOid := pbes2.KeyDerivationFunc.Algorithm
+	var key []byte
+	// zeroing the derived key after use
+	defer copy(key, make([]byte, len(key)))
+	switch {
+	case kdfOid.Equal(oidPBKDF2):
+		key, _ = deriveKeyUsingPBKDF2(pbes2.KeyDerivationFunc.Parameters.FullBytes, keySize, pkcs8Password)
+	case kdfOid.Equal(oidScrypt):
+		key, _ = deriveKeyUsingScrypt(pbes2.KeyDerivationFunc.Parameters.FullBytes, keySize, pkcs8Password)
+	default:
+		return nil, errors.New("unsupported key derivation function")
+	}
+
+	blockCipher, err := cipherMap[pbes2.EncryptionScheme.Algorithm.String()].NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	ciphertext := privKey.EncryptedData
+	mode := cipher.NewCBCDecrypter(blockCipher, iv)
+	plaintext := make([]byte, len(ciphertext))
+	mode.CryptBlocks(plaintext, ciphertext)
+
+	privateKey, err := x509.ParsePKCS8PrivateKey(plaintext)
+	if err != nil {
+		return nil, errors.New("incorrect password or invalid key format")
+	}
+
+	switch privateKey.(type) {
+	case *rsa.PrivateKey:
+		rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
+		if ok {
+			return rsaPrivateKey, nil
+		}
+	case *ecdsa.PrivateKey:
+		ecPrivateKey, ok := privateKey.(*ecdsa.PrivateKey)
+		if ok {
+			return ecPrivateKey, nil
+		}
+	default:
+		return nil, errors.New("could not parse PKCS#8 private key")
+	}
+
+	return nil, errors.New("could not parse PKCS#8 private key")
+}

--- a/aws_signing_helper/signer.go
+++ b/aws_signing_helper/signer.go
@@ -411,7 +411,7 @@ func GetSigner(opts *CredentialsOpts) (signer Signer, signatureAlgorithm string,
 			)
 		}
 
-		if !isPKCS8EncryptedPrivateKey(privateKeyId, EncryptedBlockType) {
+		if !isPKCS8EncryptedBlockType(privateKeyId) {
 			_, err = ReadPrivateKeyData(privateKeyId, opts.Pkcs8Password)
 			if err != nil {
 				return nil, "", err
@@ -794,7 +794,7 @@ func ReadPKCS12Data(certificateId string) (certChain []*x509.Certificate, privat
 	return certChain, privateKey, nil
 }
 
-// Load the private key referenced by `privateKeyId`. If `pkcs8Password` is provided, attempt to load an encrypted PKCS8 key.
+// Load the private key referenced by `privateKeyId`. If `pkcs8Password` is provided, attempt to load an encrypted PKCS#8 key.
 func ReadPrivateKeyData(privateKeyId string, pkcs8Password ...string) (crypto.PrivateKey, error) {
 	if len(pkcs8Password) > 0 && pkcs8Password[0] != "" {
 		if key, err := readPKCS8EncryptedPrivateKey(privateKeyId, []byte(pkcs8Password[0])); err == nil {

--- a/aws_signing_helper/signer.go
+++ b/aws_signing_helper/signer.go
@@ -358,7 +358,7 @@ func GetSigner(opts *CredentialsOpts) (signer Signer, signatureAlgorithm string,
 			if err != nil {
 				return nil, "", err
 			}
-			return GetFileSystemSigner(opts.PrivateKeyId, opts.CertificateId, opts.CertificateBundleId, true)
+			return GetFileSystemSigner(opts.PrivateKeyId, opts.CertificateId, opts.CertificateBundleId, true, opts.Pkcs8Password)
 		} else {
 			return nil, "", err
 		}
@@ -411,9 +411,11 @@ func GetSigner(opts *CredentialsOpts) (signer Signer, signatureAlgorithm string,
 			)
 		}
 
-		_, err = ReadPrivateKeyData(privateKeyId)
-		if err != nil {
-			return nil, "", err
+		if !isPKCS8EncryptedPrivateKey(privateKeyId, EncryptedBlockType) {
+			_, err = ReadPrivateKeyData(privateKeyId, opts.Pkcs8Password)
+			if err != nil {
+				return nil, "", err
+			}
 		}
 
 		if certificate == nil {
@@ -422,7 +424,7 @@ func GetSigner(opts *CredentialsOpts) (signer Signer, signatureAlgorithm string,
 		if Debug {
 			log.Println("attempting to use FileSystemSigner")
 		}
-		return GetFileSystemSigner(privateKeyId, opts.CertificateId, opts.CertificateBundleId, false)
+		return GetFileSystemSigner(privateKeyId, opts.CertificateId, opts.CertificateBundleId, false, opts.Pkcs8Password)
 	}
 }
 
@@ -716,30 +718,6 @@ func readRSAPrivateKey(privateKeyId string) (*rsa.PrivateKey, error) {
 	return privateKey, nil
 }
 
-func readPKCS8PrivateKey(privateKeyId string) (crypto.PrivateKey, error) {
-	block, err := parseDERFromPEM(privateKeyId, "PRIVATE KEY")
-	if err != nil {
-		return nil, errors.New("could not parse PEM data")
-	}
-
-	privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, errors.New("could not parse private key")
-	}
-
-	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
-	if ok {
-		return rsaPrivateKey, nil
-	}
-
-	ecPrivateKey, ok := privateKey.(*ecdsa.PrivateKey)
-	if ok {
-		return ecPrivateKey, nil
-	}
-
-	return nil, errors.New("could not parse PKCS#8 private key")
-}
-
 // Reads and parses a PKCS#12 file (which should contain an end-entity
 // certificate (optional), certificate chain (optional), and the key
 // associated with the end-entity certificate). The end-entity certificate
@@ -816,12 +794,20 @@ func ReadPKCS12Data(certificateId string) (certChain []*x509.Certificate, privat
 	return certChain, privateKey, nil
 }
 
-// Load the private key referenced by `privateKeyId`.
-func ReadPrivateKeyData(privateKeyId string) (crypto.PrivateKey, error) {
+// Load the private key referenced by `privateKeyId`. If `pkcs8Password` is provided, attempt to load an encrypted PKCS8 key.
+func ReadPrivateKeyData(privateKeyId string, pkcs8Password ...string) (crypto.PrivateKey, error) {
+	if len(pkcs8Password) > 0 && pkcs8Password[0] != "" {
+		if key, err := readPKCS8EncryptedPrivateKey(privateKeyId, []byte(pkcs8Password[0])); err == nil {
+			return key, nil
+		}
+		return nil, errors.New("unable to parse private key")
+	}
+
 	if key, err := readPKCS8PrivateKey(privateKeyId); err == nil {
 		return key, nil
 	}
 
+	// Try EC and RSA keys as a fallback
 	if key, err := readECPrivateKey(privateKeyId); err == nil {
 		return key, nil
 	}

--- a/aws_signing_helper/tpm_signer_test.go
+++ b/aws_signing_helper/tpm_signer_test.go
@@ -103,10 +103,10 @@ func TestTPMSignerWithCertificateBundle(t *testing.T) {
 	if err != nil {
 		var logMsg string
 		if credOpts.CertificateId != "" || credOpts.PrivateKeyId != "" {
-			logMsg = fmt.Sprintf("Failed to get signer for '%s'/'%s'",
+			logMsg = fmt.Sprintf("failed to get signer for '%s'/'%s'",
 				credOpts.CertificateId, credOpts.PrivateKeyId)
 		} else {
-			logMsg = fmt.Sprintf("Failed to get signer for '%s'",
+			logMsg = fmt.Sprintf("failed to get signer for '%s'",
 				credOpts.CertIdentifier.Subject)
 		}
 		t.Log(logMsg)

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -37,6 +37,8 @@ var (
 	tpmKeyPassword   string
 	noTpmKeyPassword bool
 
+	pkcs8Password string
+
 	credentialsOptions helper.CredentialsOpts
 
 	X509_SUBJECT_KEY = "x509Subject"
@@ -85,6 +87,7 @@ func initCredentialsSubCommand(subCmd *cobra.Command) {
 	subCmd.PersistentFlags().BoolVar(&noTpmKeyPassword, "no-tpm-key-password", false, "Required if the TPM key has no password and"+
 		"a handle is used to refer to the key")
 	subCmd.PersistentFlags().StringVar(&roleSessionName, "role-session-name", "", "An identifier of a role session")
+	subCmd.PersistentFlags().StringVar(&pkcs8Password, "pkcs8-password", "", "Password for PKCS#8 key, if applicable")
 
 	subCmd.MarkFlagsMutuallyExclusive("certificate", "cert-selector")
 	subCmd.MarkFlagsMutuallyExclusive("certificate", "system-store-name")
@@ -100,6 +103,7 @@ func initCredentialsSubCommand(subCmd *cobra.Command) {
 	subCmd.MarkFlagsMutuallyExclusive("tpm-key-password", "reuse-pin")
 	subCmd.MarkFlagsMutuallyExclusive("no-tpm-key-password", "cert-selector")
 	subCmd.MarkFlagsMutuallyExclusive("no-tpm-key-password", "tpm-key-password")
+	subCmd.MarkFlagsMutuallyExclusive("pkcs8-password", "tpm-key-password")
 }
 
 // Parses a cert selector string to a map
@@ -266,6 +270,7 @@ func PopulateCredentialsOptions() error {
 		TpmKeyPassword:               tpmKeyPassword,
 		NoTpmKeyPassword:             noTpmKeyPassword,
 		RoleSessionName:              roleSessionName,
+		Pkcs8Password:                pkcs8Password,
 	}
 
 	return nil

--- a/cmd/sign_string.go
+++ b/cmd/sign_string.go
@@ -92,6 +92,7 @@ func init() {
 		"a handle is used to refer to the key")
 	signStringCmd.PersistentFlags().Var(format, "format", "Output format. One of json, text, and bin")
 	signStringCmd.PersistentFlags().Var(digestArg, "digest", "One of SHA256, SHA384, and SHA512")
+	signStringCmd.PersistentFlags().StringVar(&pkcs8Password, "pkcs8-password", "", "Password for PKCS#8 key, if applicable")
 
 	signStringCmd.MarkFlagsMutuallyExclusive("certificate", "cert-selector")
 	signStringCmd.MarkFlagsMutuallyExclusive("certificate", "system-store-name")
@@ -106,6 +107,7 @@ func init() {
 	signStringCmd.MarkFlagsMutuallyExclusive("no-tpm-key-password", "cert-selector")
 	signStringCmd.MarkFlagsMutuallyExclusive("no-tpm-key-password", "reuse-pin")
 	signStringCmd.MarkFlagsMutuallyExclusive("no-tpm-key-password", "tpm-key-password")
+	signStringCmd.MarkFlagsMutuallyExclusive("pkcs8-password", "tpm-key-password")
 }
 
 func getFixedStringToSign(publicKey crypto.PublicKey) string {


### PR DESCRIPTION
**Description of changes:**

The credential helper now supports passing a password-encrypted private key for request signing. It supports two formats of PKCS#8 private key files:

Unencrypted: `-----BEGIN PRIVATE KEY-----`

Password-encrypted: `-----BEGIN ENCRYPTED PRIVATE KEY-----` (using PBES2)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
