### PR TITLE
Separate PKCS#11 Code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,14 @@ else
 	extra_ld_flags=
 endif
 
+ifeq ($(ROLESANYWHERE_WITH_PKCS11),)
+	# the envvar is unset, so we are NOT doing the PKCS11 build
 build/bin/aws_signing_helper:
-	go build -buildmode=pie -ldflags "-X 'github.com/aws/rolesanywhere-credential-helper/cmd.Version=${VERSION}' $(extra_ld_flags) -linkmode=external -w -s" -trimpath -o build/bin/aws_signing_helper main.go
+	go build -buildmode=pie -ldflags "-X 'github.com/aws/rolesanywhere-credential-helper/cmd.Version=${VERSION}' $(extra_ld_flags) -w -s" -trimpath -o build/bin/aws_signing_helper main.go
+else
+build/bin/aws_signing_helper:
+	CGO_ENABLED=1 go build -tags with_pkcs11 -ldflags "-X 'github.com/aws/rolesanywhere-credential-helper/cmd.Version=${VERSION}' $(extra_ld_flags) -linkmode=external -w -s" -trimpath -o build/bin/aws_signing_helper main.go
+endif
 
 .PHONY: clean
 clean: test-clean

--- a/aws_signing_helper/pkcs11_nop.go
+++ b/aws_signing_helper/pkcs11_nop.go
@@ -1,0 +1,23 @@
+//go:build !with_pkcs11
+
+package aws_signing_helper
+
+// This file exists to mock out the necessary functions called by core project code, but without actually bringing in
+// a dependency on external PKCS#11 libraries (and thus, the requirement to link to them and enable CGO).  It is
+// supposed to fail whenever called, because users who intentionally adopt the version of this code without PKCS#11
+// support should not be calling PKCS#11 functions.
+
+import (
+	"crypto/x509"
+	"errors"
+)
+
+var Pkcs11NotImplementedError = errors.New("This software has not been compiled with PKCS#11 support.")
+
+func GetPKCS11Signer(libPkcs11 string, cert *x509.Certificate, certChain []*x509.Certificate, privateKeyId string, certificateId string, reusePin bool) (signer Signer, signingAlgorithm string, err error) {
+	return nil, "", Pkcs11NotImplementedError
+}
+
+func GetMatchingPKCSCerts(uriStr string, lib string) (matchingCerts []CertificateContainer, err error) {
+	return nil, Pkcs11NotImplementedError
+}

--- a/aws_signing_helper/pkcs11_signer.go
+++ b/aws_signing_helper/pkcs11_signer.go
@@ -1,3 +1,5 @@
+//go:build with_pkcs11
+
 package aws_signing_helper
 
 // RFC7512 defines a standard URI format for referencing PKCS#11 objects.


### PR DESCRIPTION
*Issue #, if available:* #86

*Description of changes:*

This PR is a first whack at separating out the code that links to native PKCS#11 libraries on the hosts.  The goal is to build a version of `aws_signing_helper` that doesn't link to the library and so can be compiled without CGO.  It loses PKCS#11 support in the process, but that's an acceptable loss for some users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
