### PR TITLE
Add docker image build and test resources

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+docker_image_resources/

--- a/docker_image_resources/.env.template
+++ b/docker_image_resources/.env.template
@@ -1,0 +1,20 @@
+# This file provides a template for defining environment variables to
+# customize the build and test process of the credential helper docker image
+
+#Image Property Components
+#These are NOT required and DO have defaults
+VERSION=                # Docker image version tag
+REGISTRY=               # Docker registry
+IMAGE_NAME=             # Docker image name
+
+#Test Resource ARNs
+#These ARE required and do NOT have defaults
+TRUST_ANCHOR_ARN=       #Format: arn:aws:rolesanywhere:region:account:trust-anchor/id 
+PROFILE_ARN=            # Format: arn:aws:rolesanywhere:region:account:profile/id
+ROLE_ARN=               # Format: arn:aws:iam::account:role/role-name
+
+#PKI Resource Paths
+#These ARE required and DO have defaults
+#Ideally these files can be placed in the tests/certs directory
+CERTIFICATE_PATH=       # Format: path/to/certificate.pem
+PRIVATE_KEY_PATH=       # Format: path/to/private_key.pem

--- a/docker_image_resources/Dockerfile
+++ b/docker_image_resources/Dockerfile
@@ -1,0 +1,42 @@
+# Stage 1: Build the IAM Roles Anywhere Credential Helper from source
+# Version pinned to most recent stable release
+FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250527.1 AS builder
+
+# Add build argument for architecture
+ARG TARGETARCH
+
+# Install build dependencies
+RUN dnf install -y \
+    golang-1.24.3-1.amzn2023.0.1 \
+    make \
+    && dnf clean all
+
+# Set up working directory
+WORKDIR /build/rolesanywhere-credential-helper
+
+# Set GOARCH for cross-compilation
+ENV CGO_ENABLED=1
+ENV GOOS=linux
+ENV GOARCH=${TARGETARCH:-amd64}
+
+COPY .. .
+
+# Build with architecture-specific settings
+RUN make release
+
+# Stage 2: Create a minimal runtime image
+# Version pinned to most recent stable release
+FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:2025-06-11-1749625329.2023
+
+# Copy the credential helper from the builder stage
+COPY --from=builder /build/rolesanywhere-credential-helper/build/bin/aws_signing_helper /usr/local/bin/
+
+USER 65532:65532
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/aws_signing_helper"]
+
+# Add labels
+LABEL maintainer="AWS IAM Roles Anywhere" \
+      version="1.7.0" \
+      description="AWS IAM Roles Anywhere Credential Helper Docker Image"

--- a/docker_image_resources/README.md
+++ b/docker_image_resources/README.md
@@ -1,0 +1,250 @@
+# Docker Image Resources for AWS IAM Roles Anywhere Credential Helper
+
+This directory contains resources for building and testing a Docker image of the AWS IAM Roles Anywhere Credential Helper. The Docker image provides a containerized version of the credential helper that can be used in container environments like Kubernetes.
+
+## Getting Started
+
+Follow these steps to build and test the Docker image:
+
+1. **Set up environment variables**:
+   ```bash
+   # Copy the template file
+   cp .env.template myEnvironmentVariables.env
+   
+   # Edit the .env file with your values
+   vim myEnvironmentVariables.env
+   
+   # Load the environment variables
+   source myEnvironmentVariables.env
+   ```
+
+2. **Build the Docker image**:
+   ```bash
+   ./build.sh
+   ```
+   This script will install Docker if necessary and build the image for your platform.
+
+3. **Run the test suite** (optional):
+   ```bash
+   ./tests/run-tests.sh
+   ```
+   This will set up a Kind cluster, load the image, and run all tests.
+
+4. **Run individual tests** (optional):
+   ```bash
+   ./tests/scripts/run-test.sh <test-case-name>
+   ```
+   Available test cases: `serve`, `update`, `update-credentials-file`
+
+## Environment Variables
+
+The following environment variables can be configured in your `.env` file:
+
+### Image Properties (Optional)
+These have default values if not specified:
+- `VERSION` - Image version tag (default: `latest`)
+- `REGISTRY` - Docker registry (default: `local`)
+- `IMAGE_NAME` - Image name (default: `iamra-credential-helper`)
+
+### AWS Resource ARNs (Required)
+These must be specified and do not have defaults:
+- `TRUST_ANCHOR_ARN` - Format: `arn:aws:rolesanywhere:region:account:trust-anchor/id`
+- `PROFILE_ARN` - Format: `arn:aws:rolesanywhere:region:account:profile/id`
+- `ROLE_ARN` - Format: `arn:aws:iam::account:role/role-name`
+
+### PKI Resource Paths (Required)
+These have default values pointing to the test certificates:
+- `CERTIFICATE_PATH` - Path to your certificate (default: `tests/certs/certificate.pem`)
+- `PRIVATE_KEY_PATH` - Path to your private key (default: `tests/certs/private_key.pem`)
+
+## Directory Structure
+
+- `Dockerfile` - Multi-stage Dockerfile that builds the credential helper from source and creates a minimal runtime image
+- `build.sh` - Script to build the Docker image with configurable parameters and automatic Docker installation if not found
+- `.env.template` - Template for environment variables needed for building and testing
+- `tests/` - Directory containing test resources
+  - `run-tests.sh` - Script to run all tests for the Docker image
+  - `setup.sh` - Sets up the test environment (Kind cluster) with automatic installation of required tools
+  - `kind-config.yaml` - Configuration for the Kind cluster
+  - `certs/` - Test certificates used for authentication
+  - `pod_configurations/` - Kubernetes pod configurations for different test scenarios
+  - `scripts/` - Test scripts for validation and execution
+    - `run-test.sh` - Script to run individual tests
+    - `evaluate-caller-identity.sh` - Script to validate credentials using AWS STS (used by test-client in test cases)
+
+## Building the Docker Image
+
+The `build.sh` script builds the Docker image with configurable parameters:
+
+```bash
+# Build for the current architecture (amd64 or arm64 auto-detected)
+./build.sh
+```
+
+The script will:
+1. Check if Docker is installed and install it if necessary
+2. Detect your platform architecture (amd64 or arm64)
+3. Build the Docker image using `docker buildx`
+4. Create two tags:
+   - `${REGISTRY}/${IMAGE_NAME}:${VERSION}-${PLATFORM}` (platform-specific)
+   - `${REGISTRY}/${IMAGE_NAME}:${VERSION}` (default)
+
+## Testing the Docker Image
+
+### Running the Full Test Suite
+
+The `run-tests.sh` script runs all tests to verify the functionality of the Docker image:
+
+```bash
+./tests/run-tests.sh
+```
+
+This script will:
+1. Set up the test environment using `setup.sh`
+2. Run all three test cases sequentially
+3. Provide a summary of test results
+
+### Running Individual Tests
+
+You can run individual tests using the `run-test.sh` script:
+
+```bash
+./tests/scripts/run-test.sh <test-case-name> [timeout]
+```
+
+Where:
+- `<test-case-name>` is one of: `serve`, `update`, or `update-credentials-file`
+- `[timeout]` is an optional parameter specifying how long to wait for the pod to be ready (default: 30 seconds)
+
+### Test Environment Setup
+
+The `setup.sh` script prepares the test environment:
+
+1. Installs `kubectl` and `kind` if not already installed
+2. Creates a Kind cluster or uses an existing one
+3. Loads the Docker image into the Kind cluster
+4. Creates ConfigMaps for test certificates and test resources
+
+### Test Modes
+
+The Docker image is tested in three different modes:
+
+1. **Serve Mode** - Tests the credential helper in serve mode, which vends temporary credentials through a local endpoint
+   - Configuration: `tests/pod_configurations/serve.yaml`
+   - Test validates credentials using the AWS STS get-caller-identity API
+
+2. **Update Mode** - Tests the credential helper in update mode, which updates temporary credentials in the AWS credentials file
+   - Configuration: `tests/pod_configurations/update.yaml`
+   - Runs with root privileges to write to the default AWS credentials location
+   - Test validates credentials using the AWS STS get-caller-identity API
+
+3. **Update Mode (using AWS_SHARED_CREDENTIALS_FILE)** - Tests the credential helper in update mode without root privileges
+   - Configuration: `tests/pod_configurations/update-credentials-file.yaml`
+   - Uses environment variables to specify a custom credentials file location
+   - Test validates credentials using the AWS STS get-caller-identity API
+
+## Docker Image Details
+
+The Docker image is built using a multi-stage build process:
+
+1. **Build Stage**:
+   - Uses Amazon Linux 2023 as the base image
+   - Installs build dependencies (golang and make)
+   - Builds the credential helper from source
+
+2. **Runtime Stage**:
+   - Uses a minimal base image (eks-distro-minimal-base-glibc)
+   - Copies only the built binary from the build stage
+   - Runs as a non-root user (UID 65532)
+   - Sets the entrypoint to the credential helper binary
+
+## Usage Examples
+
+### Running in Serve Mode
+
+```yaml
+containers:
+- name: credential-helper
+  image: local/iamra-credential-helper:latest
+  args:
+  - "serve"
+  - "--certificate"
+  - "/certs/certificate.pem"
+  - "--private-key"
+  - "/certs/private_key.pem"
+  - "--trust-anchor-arn"
+  - "arn:aws:rolesanywhere:region:account:trust-anchor/id"
+  - "--profile-arn"
+  - "arn:aws:rolesanywhere:region:account:profile/id"
+  - "--role-arn"
+  - "arn:aws:iam::account:role/role-name"
+  volumeMounts:
+  - name: certs-volume
+    mountPath: /certs
+    readOnly: true
+```
+
+### Running in Update Mode
+
+```yaml
+containers:
+- name: credential-helper
+  image: local/iamra-credential-helper:latest
+  securityContext:
+      runAsUser: 0 #Necessary for write to root directory
+  args:
+  - "update"
+  - "--certificate"
+  - "/certs/certificate.pem"
+  - "--private-key"
+  - "/certs/private_key.pem"
+  - "--trust-anchor-arn"
+  - "arn:aws:rolesanywhere:region:account:trust-anchor/id"
+  - "--profile-arn"
+  - "arn:aws:rolesanywhere:region:account:profile/id"
+  - "--role-arn"
+  - "arn:aws:iam::account:role/role-name"
+  - "--profile"
+  - "default"
+  volumeMounts:
+  - name: certs-volume
+    mountPath: /certs
+    readOnly: true
+  - name: aws-credentials
+    mountPath: /root/.aws
+```
+
+### Running in Update Mode (using AWS_SHARED_CREDENTIALS_FILE)
+
+```yaml
+containers:
+- name: credential-helper
+  image: local/iamra-credential-helper:latest
+  env:
+  - name: AWS_SHARED_CREDENTIALS_FILE
+    value: "/tmp/.aws/credentials"
+  args:
+  - "update"
+  - "--certificate"
+  - "/certs/certificate.pem"
+  - "--private-key"
+  - "/certs/private_key.pem"
+  - "--trust-anchor-arn"
+  - "arn:aws:rolesanywhere:region:account:trust-anchor/id"
+  - "--profile-arn"
+  - "arn:aws:rolesanywhere:region:account:profile/id"
+  - "--role-arn"
+  - "arn:aws:iam::account:role/role-name"
+  - "--profile"
+  - "default"
+  volumeMounts:
+  - name: certs-volume
+    mountPath: /certs
+    readOnly: true
+  - name: aws-credentials
+    mountPath: /tmp/.aws
+```
+
+## License
+
+This project is licensed under the Apache-2.0 License. See the LICENSE file in the root directory for details.

--- a/docker_image_resources/build.sh
+++ b/docker_image_resources/build.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+VERSION="${VERSION:-latest}"
+REGISTRY="${REGISTRY:-local}"
+IMAGE_NAME="${IMAGE_NAME:-iamra-credential-helper}"
+
+if [ $(uname -m) = "x86_64" ]; then
+  PLATFORM=amd64
+elif [ $(uname -m) = "aarch64" ]; then
+  PLATFORM=arm64
+else
+  echo "Error: Invalid platform. Supported values are 'amd64' or 'arm64'"
+  exit 1
+fi
+
+if ! command -v docker &> /dev/null; then
+  echo "Docker not found, installing..."
+  # Docker installation retrieved from source: https://docs.docker.com/engine/install/ubuntu/
+  # Add Docker's official GPG key
+  apt-get update
+  apt-get install -y ca-certificates curl
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+
+  # Add the repository to Apt sources
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+  apt-get update
+
+  # Install Docker packages
+  # Pinned to most recent stable ubuntu version
+  VERSION_STRING=5:28.2.2-1~ubuntu.24.04~noble
+  apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
+
+  # Add user to the docker group
+  groupadd docker 2>/dev/null || true
+  usermod -aG docker $USER
+  
+  # Change current group ID to docker's
+  echo "Changing current user group to docker user group. If script exits call ./build.sh to continue the build"
+  newgrp docker
+
+  echo "Docker installed successfully"
+else
+  echo "Docker already installed: $(docker --version)"
+fi
+
+# Set platform-specific build arguments
+PLATFORM_ARG="--platform=linux/${PLATFORM}"
+
+# Build the image
+echo "Building ${REGISTRY}/${IMAGE_NAME}:${VERSION} for ${PLATFORM}..."
+echo ${PLATFORM_ARG}
+docker buildx build \
+  ${PLATFORM_ARG} \
+  --load \
+  -t "${REGISTRY}/${IMAGE_NAME}:${VERSION}-${PLATFORM}" \
+  -t "${REGISTRY}/${IMAGE_NAME}:${VERSION}" \
+  -f Dockerfile \
+  ..
+
+echo "Build completed successfully"
+echo "Created tags:"
+echo "- ${REGISTRY}/${IMAGE_NAME}:${VERSION}-${PLATFORM} (platform-specific)"
+echo "- ${REGISTRY}/${IMAGE_NAME}:${VERSION} (default)"

--- a/docker_image_resources/tests/kind-config.yaml
+++ b/docker_image_resources/tests/kind-config.yaml
@@ -1,0 +1,3 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: credential-helper-test

--- a/docker_image_resources/tests/pod_configurations/serve.yaml
+++ b/docker_image_resources/tests/pod_configurations/serve.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: serve-test
+spec:
+  containers:
+  - name: credential-helper
+    image: $REGISTRY/$IMAGE_NAME:$VERSION
+    imagePullPolicy: Never #Required when using a local image
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+    args:
+    - "serve"
+    - "--certificate"
+    - "/certs/certificate.pem"
+    - "--private-key"
+    - "/certs/private_key.pem"
+    - "--trust-anchor-arn"
+    - "$TRUST_ANCHOR_ARN"
+    - "--profile-arn"
+    - "$PROFILE_ARN"
+    - "--role-arn"
+    - "$ROLE_ARN"
+    - "--debug"
+    volumeMounts:
+    - name: certs-volume
+      mountPath: /certs
+      readOnly: true
+
+  - name: test-client
+    image: amazon/aws-cli:latest
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "128Mi"
+        cpu: "100m"
+    env:
+    - name: AWS_EC2_METADATA_SERVICE_ENDPOINT
+      value: "http://127.0.0.1:9911/"
+    - name: ROLE_ARN
+      value: "$ROLE_ARN"
+
+    command: 
+    - "/bin/bash"
+    - "-c"
+    - |
+      echo "Executing auth validation script..."
+      # Execute the script
+      /resources/evaluate-caller-identity.sh
+    volumeMounts:
+    - name: test-volume
+      mountPath: /resources
+
+  volumes:
+  - name: certs-volume
+    configMap:
+      name: cert-files
+  - name: test-volume
+    configMap:
+      name: test-resources
+      defaultMode: 0755 #Ensure client test script is executable

--- a/docker_image_resources/tests/pod_configurations/update-credentials-file.yaml
+++ b/docker_image_resources/tests/pod_configurations/update-credentials-file.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: update-credentials-file-test
+spec:
+  containers:
+  - name: credential-helper
+    image: $REGISTRY/$IMAGE_NAME:$VERSION
+    imagePullPolicy: Never #Required when using a local image
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+    env:
+      - name: AWS_SHARED_CREDENTIALS_FILE
+        value: "/tmp/.aws/credentials"
+    args:
+    - "update"
+    - "--certificate"
+    - "/certs/certificate.pem"
+    - "--private-key"
+    - "/certs/private_key.pem"
+    - "--trust-anchor-arn"
+    - "$TRUST_ANCHOR_ARN"
+    - "--profile-arn"
+    - "$PROFILE_ARN"
+    - "--role-arn"
+    - "$ROLE_ARN"
+    - "--debug"
+    volumeMounts:
+    - name: certs-volume
+      mountPath: /certs
+      readOnly: true
+    - name: aws-credentials
+      mountPath: /tmp/.aws
+
+  - name: test-client
+    image: amazon/aws-cli:latest
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "128Mi"
+        cpu: "100m"
+    env:
+      - name: AWS_SHARED_CREDENTIALS_FILE
+        value: "/tmp/.aws/credentials"
+      - name: ROLE_ARN
+        value: "$ROLE_ARN"
+    command:
+    - "/bin/bash"
+    - "-c"
+    - |
+      echo "Executing auth validation script..."
+      # Execute the script
+      /resources/evaluate-caller-identity.sh
+    volumeMounts:
+    - name: aws-credentials
+      mountPath: /tmp/.aws
+    - name: test-volume
+      mountPath: /resources
+
+  volumes:
+  - name: certs-volume
+    configMap:
+      name: cert-files
+  - name: aws-credentials
+    emptyDir: {}
+  - name: test-volume
+    configMap:
+      name: test-resources
+      defaultMode: 0755  #Ensure client test script is executable

--- a/docker_image_resources/tests/pod_configurations/update.yaml
+++ b/docker_image_resources/tests/pod_configurations/update.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: update-test
+spec:
+  containers:
+  - name: credential-helper
+    securityContext:
+      runAsUser: 0 #Necessary for write to root directory
+    image: $REGISTRY/$IMAGE_NAME:$VERSION
+    imagePullPolicy: Never #Required when using a local image
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+    args:
+    - "update"
+    - "--certificate"
+    - "/certs/certificate.pem"
+    - "--private-key"
+    - "/certs/private_key.pem"
+    - "--trust-anchor-arn"
+    - "$TRUST_ANCHOR_ARN"
+    - "--profile-arn"
+    - "$PROFILE_ARN"
+    - "--role-arn"
+    - "$ROLE_ARN"
+    - "--debug"
+    volumeMounts:
+    - name: certs-volume
+      mountPath: /certs
+      readOnly: true
+    - name: aws-credentials
+      mountPath: /root/.aws
+
+  - name: test-client
+    image: amazon/aws-cli:latest
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "128Mi"
+        cpu: "100m"
+    env:
+    - name: ROLE_ARN
+      value: "$ROLE_ARN"
+    command:
+    - "/bin/bash"
+    - "-c"
+    - |
+      echo "Executing auth validation script..."
+      # Execute the script
+      /resources/evaluate-caller-identity.sh
+    volumeMounts:
+    - name: aws-credentials
+      mountPath: /root/.aws
+    - name: test-volume
+      mountPath: /resources
+
+  volumes:
+  - name: certs-volume
+    configMap:
+      name: cert-files
+  - name: aws-credentials
+    emptyDir: {}
+  - name: test-volume
+    configMap:
+      name: test-resources
+      defaultMode: 0755 #Ensure client test script is executable

--- a/docker_image_resources/tests/run-tests.sh
+++ b/docker_image_resources/tests/run-tests.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+export VERSION="${VERSION:-latest}"
+export REGISTRY="${REGISTRY:-local}"
+export IMAGE_NAME="${IMAGE_NAME:-iamra-credential-helper}"
+
+
+echo "=== Starting IAM Roles Anywhere Credential Helper Tests ==="
+
+#Make scripts executable
+chmod +x tests/scripts/*.sh
+
+# Setup KinD cluster, load image and config maps
+echo "Setting up test environment..."
+./tests/setup.sh
+
+# Run tests
+echo "Running tests..."
+
+FAILED_TESTS=()
+
+# Run serve mode test
+echo "=== Running Serve Test ==="
+if ./tests/scripts/run-test.sh serve; then
+  echo "Serve mode test PASSED"
+else
+  echo "Serve mode test FAILED"
+  FAILED_TESTS+=("serve")
+fi
+
+echo ""
+
+# Run update mode test
+echo "=== Running Update Test ==="
+if ./tests/scripts/run-test.sh update; then
+  echo "Update test PASSED"
+else
+  echo "Update test FAILED"
+  FAILED_TESTS+=("update")
+fi
+
+# Run update mode non root test
+echo "=== Running Update with Credentials File Test ==="
+if ./tests/scripts/run-test.sh update-credentials-file; then
+  echo "Update with Credentials File test PASSED"
+else
+  echo "Update with Credentials File test FAILED"
+  FAILED_TESTS+=("update with credentials file")
+fi
+
+echo ""
+echo "=== Test Summary ==="
+
+# Check if any tests failed
+if [ ${#FAILED_TESTS[@]} -eq 0 ]; then
+  echo "All tests passed successfully!"
+  exit 0
+else
+  echo "The following tests failed:"
+  for test in "${FAILED_TESTS[@]}"; do
+    echo "- $test"
+  done
+  exit 1
+fi

--- a/docker_image_resources/tests/scripts/evaluate-caller-identity.sh
+++ b/docker_image_resources/tests/scripts/evaluate-caller-identity.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Test credentials and capture the output
+echo "Running get-caller-identity..."
+CALLER_IDENTITY=$(aws sts get-caller-identity --output json)
+if [ $? -ne 0 ]; then
+  echo "Failed to validate credentials with AWS"
+  exit 1
+fi
+
+echo $CALLER_IDENTITY
+
+# Extract the ARN from the response
+# Using grep and cut instead of jq since it is not available by default in the aws-cli image
+# This should be fine considering the deterministic nature of get-caller-identity responses
+CALLER_ARN=$(echo $CALLER_IDENTITY | grep -o '"Arn": "[^"]*' | cut -d'"' -f4)
+echo "Caller ARN: $CALLER_ARN"
+
+# Transform the caller ARN to match the IAM role ARN format
+# 1. Replace "sts" with "iam"
+# 2. Replace "assumed-role" with "role"
+# 3. Remove everything after the role name (the session ID)
+TRANSFORMED_ARN=$(echo $CALLER_ARN | sed 's/sts/iam/g; s/assumed-role/role/g; s/\/[^\/]*$//g')
+
+echo "Transformed ARN: $TRANSFORMED_ARN"
+echo "Expected Role ARN: $ROLE_ARN"
+
+# Compare the transformed ARN with the role ARN
+if [ "$TRANSFORMED_ARN" != "$ROLE_ARN" ]; then
+  echo "ERROR: The assumed role does not match the expected role ARN"
+  echo "Expected role ARN: $ROLE_ARN"
+  echo "Actual caller ARN: $CALLER_ARN"
+  echo "Transformed caller ARN: $TRANSFORMED_ARN"
+  exit 1
+fi
+
+echo "Role ARN verification passed successfully"
+echo "Test passed successfully"
+exit 0

--- a/docker_image_resources/tests/scripts/run-test.sh
+++ b/docker_image_resources/tests/scripts/run-test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+#set defaults in the event tests are ran outside of test driver
+export VERSION="${VERSION:-latest}"
+export REGISTRY="${REGISTRY:-local}"
+export IMAGE_NAME="${IMAGE_NAME:-iamra-credential-helper}"
+
+# Simple argument handling
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <test-case>"
+  echo "Available test cases: serve, update, update-credentials-file"
+  exit 1
+fi
+
+TEST_CASE=$1
+TIMEOUT=${2:-30}  # Optional timeout parameter with default
+
+# Validate test case
+if [ ! -f "tests/pod_configurations/${TEST_CASE}.yaml" ]; then
+  echo "Error: Invalid test case '${TEST_CASE}'"
+  exit 1
+fi
+
+# Determine the pod name and yaml file
+POD_NAME="${TEST_CASE}-test"
+
+echo "Running ${TEST_CASE} test..."
+
+# Apply the test pod and substitute required environment variables
+envsubst '$TRUST_ANCHOR_ARN,$PROFILE_ARN,$ROLE_ARN,$VERSION,$REGISTRY,$IMAGE_NAME' < "tests/pod_configurations/${TEST_CASE}.yaml" | kubectl apply -f -
+
+# Wait for pod to be ready
+echo "Waiting for pod to be ready..."
+if ! kubectl wait --for=condition=Ready "pod/${POD_NAME}" --timeout="${TIMEOUT}s"; then
+  # If pod does not become ready before timeout then show debug output
+  echo "Pod did not become ready in time. Current status:"
+  kubectl get pod "${POD_NAME}" -o wide
+  echo "Pod events:"
+  kubectl describe pod "${POD_NAME}"
+  echo "Credential helper logs (if available):"
+  kubectl logs "${POD_NAME}" -c credential-helper || echo "No logs available"
+  echo "Pod left running for debugging. Delete manually when done."
+  exit 1
+fi
+
+# Follow the test-client container logs
+echo "Test output:"
+kubectl logs -f "${POD_NAME}" -c test-client
+
+# Get the exit code of the test-client container
+TEST_EXIT_CODE=$(kubectl get pod "${POD_NAME}" --output='jsonpath={.status.containerStatuses[?(@.name=="test-client")].state.terminated.exitCode}')
+
+# Cleanup
+echo "Cleaning up..."
+kubectl delete pod "${POD_NAME}" --grace-period=0 --force
+
+# Report test result
+if [ "$TEST_EXIT_CODE" = "0" ]; then
+  echo "${TEST_CASE} test passed"
+  exit 0
+else
+  echo "${TEST_CASE} test failed with exit code: ${TEST_EXIT_CODE:-unknown}"
+  exit 1
+fi

--- a/docker_image_resources/tests/setup.sh
+++ b/docker_image_resources/tests/setup.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+export VERSION="${VERSION:-latest}"
+export REGISTRY="${REGISTRY:-local}"
+export IMAGE_NAME="${IMAGE_NAME:-iamra-credential-helper}"
+export CERTIFICATE_PATH="${CERTIFICATE_PATH:-tests/certs/certificate.pem}"
+export PRIVATE_KEY_PATH="${PRIVATE_KEY_PATH:-tests/certs/private_key.pem}"
+export CLUSTER_NAME="credential-helper-test"
+
+echo "=== Setting up IAM Roles Anywhere Credential Helper Test Environment ==="
+
+
+if [ $(uname -m) = "x86_64" ]; then
+    PLATFORM="amd64"
+elif [ $(uname -m) = "aarch64" ]; then
+    PLATFORM="arm64"
+else
+  echo "Unsupported architecture: $(uname -m)"
+  exit 1
+fi
+
+# Check and install Kind if needed
+if ! command -v kind &> /dev/null; then
+  echo "kind not found, installing..."
+  KIND_VERSION="v0.29.0"
+  # Download kind binary
+  curl -LO "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${PLATFORM}"
+  
+  # Download and verify checksum
+  echo "Verifying kind checksum..."
+  curl -LO "https://github.com/kubernetes-sigs/kind/releases/download/v0.29.0/kind-linux-${PLATFORM}.sha256sum"
+  if ! sha256sum -c kind-linux-${PLATFORM}.sha256sum; then
+    echo "ERROR: kind checksum verification failed!"
+    exit 1
+  fi
+  
+  # Rename executable after checksum is verified and install KinD
+  mv kind-linux-$PLATFORM kind
+  chmod +x ./kind
+  mv ./kind /usr/local/bin/
+  rm -f kind-linux-${PLATFORM}.sha256
+  echo "kind installed successfully"
+else
+  echo "kind already installed: $(kind --version)"
+fi
+
+# Check and install kubectl if needed
+if ! command -v kubectl &> /dev/null; then
+  echo "kubectl not found, installing..."
+  KUBECTL_VERSION="v1.33.1"
+
+  # Download kubectl binary
+  curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${PLATFORM}/kubectl"
+
+  # Download and verify checksum
+  echo "Verifying kubectl checksum..."
+  curl -LO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${PLATFORM}/kubectl.sha256
+  echo "$(cat kubectl.sha256)  kubectl" > kubectl.sha256sum
+  if ! sha256sum -c kubectl.sha256sum; then
+    echo "ERROR: kubectl checksum verification failed!"
+    exit 1
+  fi
+
+  # Install kubectl after checksum verification
+  chmod +x kubectl
+  install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+  rm -f kubectl.sha256 kubectl.sha256sum
+  echo "kubectl installed successfully"
+else
+  echo "kubectl already installed: $(kubectl version --client)"
+fi
+
+
+# Check if the desired cluster already exists. If it does then delete all existing pod configurations if they are present. 
+if kind get clusters | grep -q "^${CLUSTER_NAME}$"; then
+  echo "Cluster '${CLUSTER_NAME}' already exists, skipping creation."
+  echo "Cleaning up existing pods..."
+  kubectl delete pods --all -n default || true 
+  echo "Continuing with existing cluster..."
+else
+  # If the cluster does not exist then create it
+  echo "Creating Kind cluster..."
+  kind create cluster --config tests/kind-config.yaml
+fi
+
+# Load the image into Kind
+echo "Loading image into Kind cluster..."
+kind load docker-image "${REGISTRY}/${IMAGE_NAME}:${VERSION}" --name credential-helper-test
+
+# Create ConfigMap for certificates
+echo "Creating ConfigMap for certificates..."
+kubectl delete configmap cert-files --ignore-not-found
+kubectl create configmap cert-files \
+  --from-file=certificate.pem=$CERTIFICATE_PATH \
+  --from-file=private_key.pem=$PRIVATE_KEY_PATH
+
+# Create the ConfigMap for test-client script
+echo "Creating ConfigMap for testing resources..."
+kubectl delete configmap test-resources --ignore-not-found
+kubectl create configmap test-resources \
+  --from-file=evaluate-caller-identity.sh=tests/scripts/evaluate-caller-identity.sh
+
+echo "Setup completed successfully"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Adds a Dockerfile and build script `docker_image_resource/build.sh` for building a minimal credential helper image. 
    *  Utilizes a 2 stage build for building the credential helper image from source on Amazon Linux 2023 and copying the executable to the Amazon Linux based eks-distro-minimal-base-glibc image
* Adds a series of tests that utilize Kubernetes in Docker (KinD) for testing a series of pod configurations with the credential helper to validate auth
* Includes an environment variable template for setting up testing infrastructure and customizing builds 
* Includes a README.md for instructions on building, testing and using the image. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
