### PR TITLE
feat: prints help if no command is given

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,12 +9,15 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "aws_signing_helper [command]",
 	Short: "The credential helper is a tool to retrieve temporary AWS credentials",
-	Long: `A tool that utilizes certificates and their associated private keys to 
-sign requests to AWS IAM Roles Anywhere's CreateSession API and retrieve temporary 
-AWS security credentials. This tool exposes multiple commands to make credential 
+	Long: `A tool that utilizes certificates and their associated private keys to
+sign requests to AWS IAM Roles Anywhere's CreateSession API and retrieve temporary
+AWS security credentials. This tool exposes multiple commands to make credential
 retrieval and rotation more convenient.`,
 	Run: func(cmd *cobra.Command, args []string) {
-
+		if err := cmd.Help(); err != nil {
+			log.Println(err)
+			os.Exit(1)
+		}
 	},
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Provides help to users running credential helper with no command specified. (A good practice in cli tools that do nothing without args).

Example: 
```
aws_signing_helper
```
> A tool that utilizes certificates and their associated private keys to
sign requests to AWS IAM Roles Anywhere's CreateSession API and retrieve temporary
AWS security credentials. This tool exposes multiple commands to make credential
retrieval and rotation more convenient.
Usage:
  aws_signing_helper [command] [flags]
  aws_signing_helper [command]
Available Commands:
  completion            Generate the autocompletion script for the specified shell
  credential-process    Retrieve AWS credentials in the appropriate format for external credential processes
  help                  Help about any command
  read-certificate-data Diagnostic command to read certificate data
  serve                 Serve AWS credentials through a local endpoint
  sign-string           Signs a fixed string using the passed-in private key (or reference to private key)
  update                Updates a profile in the AWS credentials file with new AWS credentials
  version               Prints the version number of the credential helper
Flags:
  -h, --help   help for aws_signing_helper
Use "aws_signing_helper [command] --help" for more information about a command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
