### PR TITLE
Increase golang version to 1.24.5

### DIFF
--- a/docker_image_resources/Dockerfile
+++ b/docker_image_resources/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build the IAM Roles Anywhere Credential Helper from source
 # Version pinned to most recent stable release
-FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250527.1 AS builder
+FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250721.2 AS builder
 
 # Add build arguments
 ARG TARGETARCH
@@ -8,7 +8,7 @@ ARG VERSION
 
 # Install build dependencies
 RUN dnf install -y \
-    golang-1.24.3-1.amzn2023.0.1 \
+    golang-1.24.5-1.amzn2023.0.1 \
     make \
     && dnf clean all
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/aws/rolesanywhere-credential-helper
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.1


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

* Increases golang version for builds to 1.24.5 
* Also increases builder image version as well as installed go version on builder image

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
