### PR TITLE
Update version to 1.7.1

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -7,6 +7,6 @@
     <key>CFBundleIdentifier</key>
     <string>com.amazon.aws.rolesanywhere</string>
     <key>CFBundleVersion</key>
-    <string>1.7.0</string>
+    <string>1.7.1</string>
 </dict>
 </plist>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.7.0
+VERSION=1.7.1
 # IMPORTANT: This VERSION variable is parsed by the GitHub Actions image build workflow.
 # Please maintain the X.Y.Z format to ensure compatibility with the automated build process. 
 .PHONY: release

--- a/docker_image_resources/tests/.trivyignore
+++ b/docker_image_resources/tests/.trivyignore
@@ -1,2 +1,4 @@
-# We do not trigger affected codepaths in our implementation
-CVE-2025-22874
+# The CVE in question only affects using Row.Scan and Rows.Scan from the database/sql package 
+# Since we do not utilize "database/sql" the credential helper is unaffected by this vulnerability 
+# A follow-up release targeting Go 1.24.6 will be scheduled when it is made available on utilized build platforms to mitigate this vulnerability
+CVE-2025-47907


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Increments version to 1.7.1 to prepare for minor version release and adds exception for CVE-2025-47907 since it only affects go repositories utilizing the "database/sql" package. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
