### PR TITLE
add token output on stdout only if debug level is provided

### DIFF
--- a/aws_signing_helper/serve.go
+++ b/aws_signing_helper/serve.go
@@ -313,7 +313,9 @@ func Serve(port int, credentialsOptions CredentialsOpts) {
 			for key, value := range tokenMap {
 				if curTime.After(value) {
 					delete(tokenMap, key)
-					log.Printf("removed expired token: %s", key)
+					if Debug {
+						log.Printf("removed expired token: %s", key)
+					}
 				}
 			}
 			mutex.Unlock()


### PR DESCRIPTION
Fixes https://github.com/aws/rolesanywhere-credential-helper/issues/138

Add the output of the invalid token from the stdout only in Debug level. The debug level can be provided at cli argument. 
