### PR TITLE
fix: wrap errors identifying which arns are failing to parse

### DIFF
--- a/aws_signing_helper/credentials.go
+++ b/aws_signing_helper/credentials.go
@@ -61,11 +61,11 @@ func GenerateCredentials(opts *CredentialsOpts, signer Signer, signatureAlgorith
 	// Assign values to region and endpoint if they haven't already been assigned
 	trustAnchorArn, err := arn.Parse(opts.TrustAnchorArnStr)
 	if err != nil {
-		return CredentialProcessOutput{}, err
+		return CredentialProcessOutput{}, fmt.Errorf("failed to parse trust anchor arn: '%w'", err)
 	}
 	profileArn, err := arn.Parse(opts.ProfileArnStr)
 	if err != nil {
-		return CredentialProcessOutput{}, err
+		return CredentialProcessOutput{}, fmt.Errorf("failed to parse profile arn: '%w'", err)
 	}
 
 	if trustAnchorArn.Region != profileArn.Region {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tells you which arn failed to parse, trust anchor vs profile by wrapping the error with a custom message

Before:
2025/11/10 14:25:36 arn: invalid prefix

After:
2025/11/10 14:48:38 failed to parse trust anchor arn: 'arn: invalid prefix'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
