### PR TITLE
Chore serve command - no trailing slash redirect, parity with ec2 metadata

### DIFF
--- a/aws_signing_helper/serve_test.go
+++ b/aws_signing_helper/serve_test.go
@@ -1,0 +1,56 @@
+package aws_signing_helper
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSetupHandlers(t *testing.T) {
+	roleName := "roleName"
+
+	mockPutTokenHandler := func(w http.ResponseWriter, r *http.Request) {}
+	mockGetRoleNameHandler := func(w http.ResponseWriter, r *http.Request) {}
+	mockGetCredentialsHandler := func(w http.ResponseWriter, r *http.Request) {}
+
+	handler := setupHandlers(roleName, mockPutTokenHandler, mockGetRoleNameHandler, mockGetCredentialsHandler)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	testCases := []struct {
+		name   string
+		path   string
+		method string
+	}{
+		{"PutTokenHandler without trailing slash", TOKEN_RESOURCE_PATH, "PUT"},
+		{"PutTokenHandler with trailing slash", TOKEN_RESOURCE_PATH_WITH_TRAILING_SLASH, "PUT"},
+		{"GetRoleNameHandler without trailing slash", SECURITY_CREDENTIALS_RESOURCE_PATH, "GET"},
+		{"GetRoleNameHandler with trailing slash", SECURITY_CREDENTIALS_RESOURCE_PATH_WITH_TRAILING_SLASH, "GET"},
+		{"GetCredentialsHandler without trailing slash", SECURITY_CREDENTIALS_RESOURCE_PATH_WITH_TRAILING_SLASH + roleName, "GET"},
+		{"GetCredentialsHandler with trailing slash", SECURITY_CREDENTIALS_RESOURCE_PATH_WITH_TRAILING_SLASH + roleName + "/", "GET"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(tc.method, server.URL+tc.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			client := &http.Client{
+				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if status := resp.StatusCode; status != http.StatusOK {
+				t.Errorf("handler for %s returned wrong status code: got %v want %v", tc.path, status, http.StatusOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `serve ` command has a trailing slash redirect, IMDSv2 doesn't redirect if a trailing slash is present/not present.

Reproduction steps on an EC2 instance in us-east-1

```
[ec2-user@ip-172-31-48-206 ~]$ TOKEN=$(curl --fail-with-body --no-progress-meter -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" http://127.0.0.1:9911/latest/api/token)
[ec2-user@ip-172-31-48-206 ~]$ curl --fail-with-body --no-progress-meter -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials
my-role
[ec2-user@ip-172-31-48-206 ~]$ curl --fail-with-body --no-progress-meter -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/
my-role
```

When the same requests goes through the `aws_signing_helper serve` command's server a redirect is done, breaking parity

```
clickhouse-cluster-server-0:/# TOKEN=$(curl --fail-with-body --no-progress-meter -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" http://127.0.0.1:9911/latest/api/token)

clickhouse-cluster-server-0:/# curl --fail-with-body --no-progress-meter -H "X-aws-ec2-metadata-token: $TOKEN" http://127.0.0.1:9911/latest/meta-data/iam/security-credentials
<a href="/latest/meta-data/iam/security-credentials/">Moved Permanently</a>.

clickhouse-cluster-server-0:/# curl --fail-with-body --no-progress-meter -H "X-aws-ec2-metadata-token: $TOKEN" http://127.0.0.1:9911/latest/meta-data/iam/security-credentials/
my-role
```

Not a Go expert but, looked through the [docs ](https://pkg.go.dev/net/http#hdr-Trailing_slash_redirection-ServeMux) and as mentioned there I created a separate listener for the paths with a trailing slash, time complexity should be the same as previously as no wildcards/regexes were added. I've extracted the routes in a router to allow for creating a simple test.

I discovered this imparity while trying to setup `ClickHouse` to work with IAM Roles Anywhere, as it doesn't support this redirect. I've tested my change and both `aws-cli` and `ClickHouse` work nicely with it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
