### PR TITLE
Increase golang version to 1.24.9

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner_image: macos-13
+          - runner_image: macos-15-intel
             arch: "X86_64"
             display_name: "MacOS X86_64"
           - runner_image: macos-14

--- a/docker_image_resources/Dockerfile
+++ b/docker_image_resources/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build the IAM Roles Anywhere Credential Helper from source
 # Version pinned to most recent stable release
-FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250721.2 AS builder
+FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023.9.20251110.1 AS builder
 
 # Add build arguments
 ARG TARGETARCH
@@ -8,7 +8,7 @@ ARG VERSION
 
 # Install build dependencies
 RUN dnf install -y \
-    golang-1.24.5-1.amzn2023.0.1 \
+    golang-1.24.9-1.amzn2023.0.1 \
     make \
     && dnf clean all
 
@@ -27,7 +27,7 @@ RUN make release
 
 # Stage 2: Create a minimal runtime image
 # Version pinned to most recent stable release
-FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:2025-06-11-1749625329.2023
+FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:2025-11-11-1762887692.2023
 
 # Add build argument for version in final stage
 ARG VERSION

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/rolesanywhere-credential-helper
 
 go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.24.9
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.1


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Upgrades go toolchain used to 1.24.9 
* Updates builder and actual image of the credential helper docker image to latest for both. 
* Updates docker image go dependency to 1.24.9
* Upgrade resolves all found vulnerabilities as of 11/17

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
