### PR TITLE
debug: add logging for canonical request, string to sign, and signature

### DIFF
--- a/aws_signing_helper/signer.go
+++ b/aws_signing_helper/signer.go
@@ -500,8 +500,14 @@ func signRequest(signer crypto.Signer, signingRegion string, signingAlgorithm st
 	}
 
 	canonicalRequest, signedHeadersString := createCanonicalRequest(req, payloadHash)
+	if Debug {
+		log.Println("Canonical Request Hash: " + canonicalRequest)
+	}
 
 	stringToSign := CreateStringToSign(canonicalRequest, signerParams)
+	if Debug {
+		log.Println("String to sign: " + stringToSign)
+	}
 	signatureBytes, err := signer.Sign(rand.Reader, []byte(stringToSign), crypto.SHA256)
 	if err != nil {
 		log.Println("could not sign request", err)
@@ -608,6 +614,10 @@ func createCanonicalRequest(r *http.Request, contentSha256 string) (string, stri
 	canonicalRequestStrBuilder.WriteString("\n")
 	canonicalRequestStrBuilder.WriteString(contentSha256)
 	canonicalRequestString := canonicalRequestStrBuilder.String()
+	if Debug {
+		log.Println("Canonical URL: " + r.URL.String())
+		log.Println("Canonical Request: ", canonicalRequestString)
+	}
 	canonicalRequestStringHashBytes := sha256.Sum256([]byte(canonicalRequestString))
 	return hex.EncodeToString(canonicalRequestStringHashBytes[:]), signedHeadersString
 }
@@ -642,6 +652,9 @@ func BuildAuthorizationHeader(request *http.Request, signedHeadersString string,
 	authHeaderStringBuilder.WriteString(", ")
 	authHeaderStringBuilder.WriteString(signatureHeader)
 	authHeaderString := authHeaderStringBuilder.String()
+	if Debug {
+		log.Println("AuthorizationHeaderString: " + authHeaderString)
+	}
 	return authHeaderString
 }
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
- Add debug logging for canonical request hash and full request
- Add debug logging for string to sign
- Add debug logging for authorization header

Feel free to point out any concerns with this change, Willing to drop the auth header debug logging to get the rest through.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
