### PR TITLE
Increased golang version to 1.24.11 and updated x86 Mac Builds

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner_image: macos-13
+          - runner_image: macos-15-intel
             arch: "X86_64"
             display_name: "MacOS X86_64"
           - runner_image: macos-14
@@ -30,6 +30,14 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+
+      - name: Set build flag environment variables for Sonoma compatability if build is on x86
+        run: |
+          if [[ "${{ matrix.arch }}" == "X86_64" ]]; then
+            echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+            echo "CGO_CFLAGS=-mmacosx-version-min=14.0" >> $GITHUB_ENV
+            echo "CGO_LDFLAGS=-mmacosx-version-min=14.0" >> $GITHUB_ENV
+          fi
 
       - name: Build Project
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
             tpm: true
             pkcs11: true
           - name: macOS x64
-            os: macos-13
+            os: macos-15-intel
             pkcs11: true
           - name: macOS ARM
             os: macos-14
@@ -61,6 +61,13 @@ jobs:
       - name: Base tests (Linux)
         if: runner.os == 'Linux'
         run: nix-shell nix/shell-base.nix --run 'dbus-run-session -- bash -c "rm -rf tst/swtpm && make test"'
+
+      - name: Set build flag environment variables for Sonoma compatability on x86 Mac
+        if: matrix.os == 'macos-15-intel'
+        run: |
+            echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+            echo "CGO_CFLAGS=-mmacosx-version-min=14.0" >> $GITHUB_ENV
+            echo "CGO_LDFLAGS=-mmacosx-version-min=14.0" >> $GITHUB_ENV
 
       - name: Base tests (macOS)
         if: runner.os == 'macOS'

--- a/docker_image_resources/Dockerfile
+++ b/docker_image_resources/Dockerfile
@@ -12,6 +12,19 @@ RUN dnf install -y \
     make \
     && dnf clean all
 
+ENV GOPATH=/root/go \
+    PATH=/root/go/bin:$PATH \
+    HOME=/root \
+ 
+RUN mkdir -p /root/go/bin && \
+    go install golang.org/dl/go1.24.11@latest && \
+    go1.24.11 download && \
+    rm -rf /usr/local/go && \
+    ln -s /root/sdk/go1.24.11 /usr/local/go
+ 
+ENV GOROOT=/usr/local/go \
+    PATH=/usr/local/go/bin:/root/go/bin:$PATH
+
 # Set up working directory
 WORKDIR /build/rolesanywhere-credential-helper
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/rolesanywhere-credential-helper
 
 go 1.24.0
 
-toolchain go1.24.9
+toolchain go1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Increased golang version to 1.24.11
* Updated runners for x86 Mac build and test actions from 13 to 15 since it was deprecated
* Added build flags to make x86 builds compatible with minimum version 14 (Sonoma)
* Added manual install of golang 1.24.11 to the builder image of the credential helper image since 1.24.9 is the maximum supported version by the package manager.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
