### PR TITLE
fix(serve): graceful shutdown on SIGTERM/SIGINT (exit 0)

### DIFF
--- a/aws_signing_helper/serve.go
+++ b/aws_signing_helper/serve.go
@@ -1,6 +1,7 @@
 package aws_signing_helper
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -11,9 +12,11 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -351,7 +354,22 @@ func Serve(port int, credentialsOptions CredentialsOpts) {
 	log.Println("Local server started on port:", endpoint.PortNum)
 	log.Println("Make it available to the sdk by running:")
 	log.Printf("export AWS_EC2_METADATA_SERVICE_ENDPOINT=http://%s:%d/", LocalHostAddress, endpoint.PortNum)
-	if err := endpoint.Server.Serve(listener); err != nil {
+
+	// Graceful shutdown on SIGTERM/SIGINT
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-quit
+		log.Println("Shutting down server...")
+		ticker.Stop()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := endpoint.Server.Shutdown(ctx); err != nil {
+			log.Println("Server forced to shutdown:", err)
+		}
+	}()
+
+	if err := endpoint.Server.Serve(listener); err != nil && err != http.ErrServerClosed {
 		log.Println("Httpserver: ListenAndServe() error")
 		os.Exit(1)
 	}


### PR DESCRIPTION
  ## Problem

  The `serve` command has no signal handler. When Kubernetes sends `SIGTERM`
  to the container (e.g. during pod shutdown, rolling update, or job completion
  with native sidecars), Go's default signal handling terminates the process
  with **exit code 2**.

  This causes Kubernetes to report the sidecar container as `reason: Error`
  even when the pod/job completed successfully. See issue #176.

  ## Fix

  Add a signal handler in `Serve()` that:
  1. Listens for `SIGTERM` and `SIGINT` on a buffered channel
  2. Calls `server.Shutdown()` with a 5-second context to allow in-flight requests to complete
  3. Returns naturally from `Serve()` via `http.ErrServerClosed` → **exit code 0**

  ## Testing

  ```bash
  # Start server in background, send SIGTERM, verify exit 0
  ./aws_signing_helper serve --certificate cert.pem --private-key key.pem ... --port 19911 &
  PID=$!
  sleep 1 && kill -TERM $PID && wait $PID
  echo "Exit code: $?"  # → 0
```

  Fixes #176