### PR TITLE
Update Go version to 1.26.1 to fix security vulnerabilities

### DIFF
--- a/docker_image_resources/Dockerfile
+++ b/docker_image_resources/Dockerfile
@@ -17,10 +17,10 @@ ENV GOPATH=/root/go \
     HOME=/root
  
 RUN mkdir -p /root/go/bin && \
-    go install golang.org/dl/go1.24.13@latest && \
-    go1.24.13 download && \
+    go install golang.org/dl/go1.26.1@latest && \
+    go1.26.1 download && \
     rm -rf /usr/local/go && \
-    ln -s /root/sdk/go1.24.13 /usr/local/go
+    ln -s /root/sdk/go1.26.1 /usr/local/go
  
 ENV GOROOT=/usr/local/go \
     PATH=/usr/local/go/bin:/root/go/bin:$PATH

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/aws/rolesanywhere-credential-helper
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.13
+toolchain go1.26.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0


### PR DESCRIPTION
*Description of changes:*

Upgrade the go toolchain version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
