### PR TITLE
Update Go version to 1.26.2 to fix security vulnerabilities

### DIFF
--- a/docker_image_resources/Dockerfile
+++ b/docker_image_resources/Dockerfile
@@ -5,6 +5,7 @@ FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023.9.20
 # Add build arguments
 ARG TARGETARCH
 ARG VERSION
+ARG GO_VERSION=1.26.2
 
 # Install build dependencies
 RUN dnf install -y \
@@ -17,10 +18,10 @@ ENV GOPATH=/root/go \
     HOME=/root
  
 RUN mkdir -p /root/go/bin && \
-    go install golang.org/dl/go1.26.1@latest && \
-    go1.26.1 download && \
+    go install golang.org/dl/go${GO_VERSION}@latest && \
+    go${GO_VERSION} download && \
     rm -rf /usr/local/go && \
-    ln -s /root/sdk/go1.26.1 /usr/local/go
+    ln -s /root/sdk/go${GO_VERSION} /usr/local/go
  
 ENV GOROOT=/usr/local/go \
     PATH=/usr/local/go/bin:/root/go/bin:$PATH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/rolesanywhere-credential-helper
 
 go 1.26.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0


### PR DESCRIPTION
*Description of changes:*
Update Go version to 1.26.2 to fix security vulnerabilities

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
