### PR TITLE
Bump the credential helper to v1.8.2

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -7,6 +7,6 @@
     <key>CFBundleIdentifier</key>
     <string>com.amazon.aws.rolesanywhere</string>
     <key>CFBundleVersion</key>
-    <string>1.8.1</string>
+    <string>1.8.2</string>
 </dict>
 </plist>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.8.1
+VERSION=1.8.2
 # IMPORTANT: This VERSION variable is parsed by the GitHub Actions image build workflow.
 # Please maintain the X.Y.Z format to ensure compatibility with the automated build process.
 .PHONY: release


### PR DESCRIPTION
*Description of changes:*
Bump the credential helper to v1.8.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
