### PR TITLE
fix(docker-build): docker wasn't setup to build fixtures, reverting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION=1.8.2
 # IMPORTANT: This VERSION variable is parsed by the GitHub Actions image build workflow.
 # Please maintain the X.Y.Z format to ensure compatibility with the automated build process.
 .PHONY: release
-release: test-certs mldsa-fixtures build/bin/aws_signing_helper
+release: build/bin/aws_signing_helper
 
 curdir=$(shell pwd)
 uname=$(shell uname -s)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

My suggestion to start having release also test/setup tests before building doesn't work for docker builds, reverting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
