### PR TITLE
Bump helper version and improve PR testing

### DIFF
--- a/.github/workflows/build_and_test_docker_image.yml
+++ b/.github/workflows/build_and_test_docker_image.yml
@@ -3,6 +3,11 @@ name: Build and Test Credential Helper Docker Image
 on:
   push:
     branches: [ main ]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
   STAGING_REGISTRY: 264252446756.dkr.ecr.us-east-1.amazonaws.com
@@ -16,7 +21,7 @@ permissions:
 
 jobs:
   build-and-push:
-    name: Build Docker Images and Push to Staging Repository
+    name: Build Docker Images (${{ matrix.platform }})
     strategy:
       matrix:
         include:
@@ -31,12 +36,14 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         
       - name: Configure AWS credentials
+        if: github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper'
         uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           role-to-assume: arn:aws:iam::264252446756:role/GithubActionsAccessRole
           aws-region: ${{ env.AWS_REGION }}
           
       - name: Login to Amazon ECR
+        if: github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
@@ -44,24 +51,57 @@ jobs:
         id: extract-version
         run: |
           VERSION=$(grep '^VERSION=' Makefile | cut -d'=' -f2)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Extracted version: $VERSION"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Extract Go version from go.mod
+        id: go-version
+        run: |
+          GO_VERSION=$(grep '^toolchain' go.mod | awk '{print $2}' | sed 's/go//')
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+          fi
+          echo "version=${GO_VERSION}" >> "$GITHUB_OUTPUT"
+
+      # push=true outputs to registry (--output=type=registry)
+      # load=true outputs to local daemon only (--output=type=docker)
+      # See: https://github.com/docker/build-push-action#inputs
+      # See: https://docs.docker.com/build/ci/github-actions/test-before-push/
       - name: Build and Push Docker image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./docker_image_resources/Dockerfile
           platforms: linux/${{ matrix.platform }}
-          push: true
+          push: ${{ github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper' }}
+          load: ${{ !(github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper') }}
           build-args: |
             VERSION=${{ steps.extract-version.outputs.version }}
+            GO_VERSION=${{ steps.go-version.outputs.version }}
           tags: |
             ${{ env.STAGING_REGISTRY }}/${{ env.STAGING_REPOSITORY }}:${{ github.sha }}-${{ matrix.platform }}
           provenance: false # provenance must be disabled in order to prevent manifest creation failures
 
+      - name: Verify image runs
+        if: "!(github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper')"
+        run: |
+          docker run --rm "${{ env.STAGING_REGISTRY }}/${{ env.STAGING_REPOSITORY }}:${{ github.sha }}-${{ matrix.platform }}" version
+
+      - name: Install Trivy Image Scanner
+        if: "!(github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper')"
+        uses: aquasecurity/setup-trivy@7483281e2107e7eecac919ed9d4f5ce2d89e4614 # v0.2.0
+        with:
+          cache: true
+          version: v0.69.3
+
+      - name: Scan Docker image with Trivy
+        if: "!(github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper')"
+        run: |
+          IMAGE_REFERENCE="${{ env.STAGING_REGISTRY }}/${{ env.STAGING_REPOSITORY }}:${{ github.sha }}-${{ matrix.platform }}"
+          ./docker_image_resources/tests/scripts/scan-image.sh "$IMAGE_REFERENCE"
+
   test-and-scan:
     name: Test and Scan Docker Images
+    if: github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper'
     needs: build-and-push
     strategy:
       matrix:
@@ -92,7 +132,7 @@ jobs:
         run: |
           MAX_PULL_ATTEMPTS=3
           PULL_ATTEMPT=0
-          until docker pull ${{ env.STAGING_REGISTRY }}/${{ env.STAGING_REPOSITORY }}:${{ github.sha }}-${{matrix.platform}}; do
+          until docker pull "${{ env.STAGING_REGISTRY }}/${{ env.STAGING_REPOSITORY }}:${{ github.sha }}-${{matrix.platform}}"; do
               PULL_ATTEMPT=$((PULL_ATTEMPT + 1))
               if [ $PULL_ATTEMPT -ge $MAX_PULL_ATTEMPTS ]; then
                   echo "Failed to pull image after $MAX_PULL_ATTEMPTS attempts"
@@ -102,7 +142,7 @@ jobs:
               sleep 10
           done
             
-          echo "REPOSITORY=${{ env.STAGING_REPOSITORY }}" >> $GITHUB_ENV
+          echo "REPOSITORY=${{ env.STAGING_REPOSITORY }}" >> "$GITHUB_ENV"
 
           mkdir -p docker_image_resources/tests/certs
           
@@ -118,7 +158,7 @@ jobs:
         run: |
           # Run basic version test
           echo "Testing version command:"
-          docker run --rm ${{ env.STAGING_REGISTRY }}/${{ env.STAGING_REPOSITORY }}:${{ github.sha }}-${{matrix.platform}} version
+          docker run --rm "${{ env.STAGING_REGISTRY }}/${{ env.STAGING_REPOSITORY }}:${{ github.sha }}-${{matrix.platform}}" version
 
           # Run Integration Tests 
           cd docker_image_resources

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -3,6 +3,11 @@ name: Amazon Linux 2023 build and test rolesanywhere-credential-helper
 on:
   push:
     branches: [ main ]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   statuses: write
@@ -34,7 +39,10 @@ jobs:
         id: go-version
         run: |
           GO_VERSION=$(grep '^toolchain' go.mod | awk '{print $2}' | sed 's/go//')
-          echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+          fi
+          echo "version=${GO_VERSION}" >> "$GITHUB_OUTPUT"
       
       - name: Build Docker image
         run: |
@@ -53,6 +61,7 @@ jobs:
             bash -c "make release"
       
       - name: Configure AWS credentials
+        if: github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper'
         uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           role-to-assume: ${{ secrets.BINARY_BUILDING_ROLE_ARN }}
@@ -60,6 +69,7 @@ jobs:
           aws-region: us-west-2
       
       - name: Upload to S3
+        if: github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper'
         id: s3
         run: |
           S3_DESTINATION="s3://${{ secrets.INTERMEDIATE_BUCKET_NAME }}"

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -2,6 +2,11 @@ name: MacOS build and test rolesanywhere-credential-helper
 on:
   push:
     branches: [ main ]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   statuses: write
@@ -52,6 +57,7 @@ jobs:
           make test
 
       - name: Configure AWS credentials
+        if: github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper'
         uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           role-to-assume: ${{ secrets.BINARY_BUILDING_ROLE_ARN }}
@@ -59,6 +65,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Upload to S3
+        if: github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper'
         id: s3
         run: |
           S3_DESTINATION="s3://${{ secrets.INTERMEDIATE_BUCKET_NAME }}"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,8 +2,13 @@ name: Unit Tests
 
 on:
   push:
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   tests:
@@ -65,9 +70,11 @@ jobs:
       - name: Set build flag environment variables for Sonoma compatability on x86 Mac
         if: matrix.os == 'macos-15-intel'
         run: |
-            echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
-            echo "CGO_CFLAGS=-mmacosx-version-min=14.0" >> $GITHUB_ENV
-            echo "CGO_LDFLAGS=-mmacosx-version-min=14.0" >> $GITHUB_ENV
+            {
+              echo "MACOSX_DEPLOYMENT_TARGET=14.0"
+              echo "CGO_CFLAGS=-mmacosx-version-min=14.0"
+              echo "CGO_LDFLAGS=-mmacosx-version-min=14.0"
+            } >> "$GITHUB_ENV"
 
       - name: Base tests (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -3,6 +3,11 @@ name: Windows build and test rolesanywhere-credential-helper
 on:
   push:
     branches: [ main ]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   statuses: write
@@ -41,6 +46,7 @@ jobs:
         shell: pwsh
       
       - name: Configure AWS credentials
+        if: github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper'
         uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           role-to-assume: ${{ secrets.BINARY_BUILDING_ROLE_ARN }}
@@ -48,6 +54,7 @@ jobs:
           aws-region: us-west-2
       
       - name: Upload to S3
+        if: github.event_name == 'push' && github.repository == 'aws/rolesanywhere-credential-helper'
         id: s3
         run: |
           $S3_DESTINATION = "s3://${{ secrets.INTERMEDIATE_BUCKET_NAME }}"

--- a/Info.plist
+++ b/Info.plist
@@ -7,6 +7,6 @@
     <key>CFBundleIdentifier</key>
     <string>com.amazon.aws.rolesanywhere</string>
     <key>CFBundleVersion</key>
-    <string>1.8.2</string>
+    <string>1.8.3</string>
 </dict>
 </plist>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.8.2
+VERSION=1.8.3
 # IMPORTANT: This VERSION variable is parsed by the GitHub Actions image build workflow.
 # Please maintain the X.Y.Z format to ensure compatibility with the automated build process.
 .PHONY: release
@@ -366,7 +366,7 @@ $(MLDSAKEYS):
 	ALGO_UPPER=$$(echo "$@" | sed 's/.*\/\(mldsa[0-9]*\)-key.pem/\1/' | sed 's/mldsa\([0-9][0-9]\)/ML-DSA-\1/'); \
 	openssl genpkey -algorithm $${ALGO_UPPER} -out $@
 
-$(certsdir)/cert-bundle.pem: $(RSACERTS) $(ECCERTS) 
+$(certsdir)/cert-bundle.pem: $(RSACERTS) $(ECCERTS)
 	cat $^ > $@
 
 $(certsdir)/cert-bundle-with-comments.pem: $(RSACERTS) $(ECCERTS)

--- a/docker_image_resources/Dockerfile
+++ b/docker_image_resources/Dockerfile
@@ -1,15 +1,15 @@
 # Stage 1: Build the IAM Roles Anywhere Credential Helper from source
 # Version pinned to most recent stable release
-FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023.9.20251110.1 AS builder
+FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023.11.20260509.0 AS builder
 
 # Add build arguments
 ARG TARGETARCH
 ARG VERSION
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION
 
 # Install build dependencies
 RUN dnf install -y \
-    golang-1.24.9-1.amzn2023.0.1 \
+    golang-1.25.9-1.amzn2023.0.1 \
     make \
     && dnf clean all
 
@@ -41,7 +41,7 @@ RUN make release
 
 # Stage 2: Create a minimal runtime image
 # Version pinned to most recent stable release
-FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:2025-11-11-1762887692.2023
+FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc:2026-05-11-1778526103.2023
 
 # Add build argument for version in final stage
 ARG VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/aws/rolesanywhere-credential-helper
 
-go 1.26.0
-
-toolchain go1.26.3
+go 1.26.3
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/nix/shell-base.nix
+++ b/nix/shell-base.nix
@@ -1,4 +1,9 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import (builtins.fetchTarball {
+    # nixpkgs with Go 1.26.2
+    # To update: find a nixpkgs commit with the desired Go version at
+    # https://www.nixhub.io/packages/go then replace the commit hash below.
+    url = "https://github.com/NixOS/nixpkgs/archive/01fbdeef22b76df85ea168fbfe1bfd9e63681b30.tar.gz";
+  }) {} }:
 
 pkgs.mkShell {
   buildInputs = with pkgs; [

--- a/nix/shell-pkcs11.nix
+++ b/nix/shell-pkcs11.nix
@@ -1,4 +1,9 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import (builtins.fetchTarball {
+    # nixpkgs with Go 1.26.2
+    # To update: find a nixpkgs commit with the desired Go version at
+    # https://www.nixhub.io/packages/go then replace the commit hash below.
+    url = "https://github.com/NixOS/nixpkgs/archive/01fbdeef22b76df85ea168fbfe1bfd9e63681b30.tar.gz";
+  }) {} }:
 
 let
   base = import ./shell-base.nix { inherit pkgs; };

--- a/nix/shell-tpm.nix
+++ b/nix/shell-tpm.nix
@@ -1,4 +1,9 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import (builtins.fetchTarball {
+    # nixpkgs with Go 1.26.2
+    # To update: find a nixpkgs commit with the desired Go version at
+    # https://www.nixhub.io/packages/go then replace the commit hash below.
+    url = "https://github.com/NixOS/nixpkgs/archive/01fbdeef22b76df85ea168fbfe1bfd9e63681b30.tar.gz";
+  }) {} }:
 
 let
   base = import ./shell-base.nix { inherit pkgs; };


### PR DESCRIPTION
 **Issue #, if available:**

  N/A

  **Description of changes:**

  Add pull_request triggers to all CI workflows so PRs get validated before merge, without exposing credentials or pushing artifacts. Update Docker base images to resolve 3 High Trivy vulnerabilities.

**Changes:**
  - Update Docker base images (builder: AL2023 2023.11.20260509.0, runtime: eks-distro-minimal-base-glibc 2026-05-11)
  - Remove test-certs dependency from `make release` (not needed for binary build)
  - Pin nixpkgs to Go 1.26.2
  - Run `go mod tidy` (remove redundant toolchain directive)
  - Add `pull_request` trigger to all build workflows (push scoped to main only)
  - Add concurrency groups with cancel-in-progress
  - Gate AWS credentials, ECR login, S3 upload, and docker push on upstream repo
  - Docker build uses `load: true` (local only) when not on upstream push
  - Run verify + Trivy scan locally against loaded image on PRs
  - Extract GO_VERSION from go.mod with toolchain/go directive fallback
  - Fix shellcheck warnings in unit_tests.yml
  - Bump version 1.8.2 → 1.8.3

  **Security:** PRs cannot trigger credential usage — double-gated on `github.event_name == 'push'` AND `github.repository == 'aws/rolesanywhere-credential-helper'`. Docker `push` parameter uses the same guard; forks always `load` locally.

**Testing:** New PR testing/dry-running was validated with my fork: https://github.com/camerondugan/rolesanywhere-credential-helper/pull/1 and this PR is using the new workflows.

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.