### PR TITLE
refactor(serve): use signal.NotifyContext for graceful shutdown

### DIFF
--- a/aws_signing_helper/serve.go
+++ b/aws_signing_helper/serve.go
@@ -356,15 +356,16 @@ func Serve(port int, credentialsOptions CredentialsOpts) {
 	log.Printf("export AWS_EC2_METADATA_SERVICE_ENDPOINT=http://%s:%d/", LocalHostAddress, endpoint.PortNum)
 
 	// Graceful shutdown on SIGTERM/SIGINT
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
 	go func() {
-		<-quit
+		<-ctx.Done()
 		log.Println("Shutting down server...")
 		ticker.Stop()
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := endpoint.Server.Shutdown(ctx); err != nil {
+		if err := endpoint.Server.Shutdown(shutdownCtx); err != nil {
 			log.Println("Server forced to shutdown:", err)
 		}
 	}()

--- a/aws_signing_helper/serve_test.go
+++ b/aws_signing_helper/serve_test.go
@@ -1,10 +1,81 @@
+//go:build !windows
+
 package aws_signing_helper
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os/signal"
+	"syscall"
 	"testing"
+	"time"
 )
+
+func TestGracefulShutdown(t *testing.T) {
+	// Set up a minimal server using the same pattern as Serve()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &http.Server{Handler: mux}
+
+	// Mirror the signal handling logic from Serve()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	shutdownComplete := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		srv.Shutdown(shutdownCtx)
+		close(shutdownComplete)
+	}()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Serve(listener)
+	}()
+
+	// Verify server is accepting connections
+	resp, err := http.Get("http://" + listener.Addr().String() + "/health")
+	if err != nil {
+		t.Fatal("server not ready:", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Trigger shutdown via signal
+	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+
+	// Verify server shuts down cleanly
+	select {
+	case <-shutdownComplete:
+		// Success
+	case <-time.After(10 * time.Second):
+		t.Fatal("shutdown did not complete within timeout")
+	}
+
+	// Serve should return ErrServerClosed
+	select {
+	case err := <-serveErr:
+		if err != http.ErrServerClosed {
+			t.Fatalf("expected ErrServerClosed, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return")
+	}
+}
 
 func TestSetupHandlers(t *testing.T) {
 	roleName := "roleName"


### PR DESCRIPTION
Replace manual channel+goroutine signal handling with signal.NotifyContext. Add TestGracefulShutdown to verify SIGTERM triggers clean shutdown with http.ErrServerClosed.

Fast follow for #177 fixing minor concerns
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
