### PR TITLE
fix(windows): detect end of cert chain enumeration by error code instead of localized message

### DIFF
--- a/aws_signing_helper/cert_store_signer_windows.go
+++ b/aws_signing_helper/cert_store_signer_windows.go
@@ -44,6 +44,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"unsafe"
 )
 
@@ -177,7 +178,10 @@ func GetMatchingCertsAndChain(certIdentifier CertIdentifier) (store windows.Hand
 		// Previous chainCtx should be freed here if it isn't nil
 		chainCtx, err = windows.CertFindChainInStore(store, encoding, flags, findType, paramsPtr, chainCtx)
 		if err != nil {
-			if strings.Contains(err.Error(), "Cannot find object or property.") {
+			// CertFindChainInStore sets CRYPT_E_NOT_FOUND when the
+			// enumeration is complete. Match on the error code rather than
+			// its message, which is localized on non-English systems.
+			if errors.Is(err, syscall.Errno(windows.CRYPT_E_NOT_FOUND)) {
 				break
 			}
 			err = errors.New("unable to find certificate chain in store")


### PR DESCRIPTION
*Issue #, if available:* #192

*Description of changes:*

On non-English Windows (no English language pack installed), every certificate store operation fails with `unable to find certificate chain in store`, because the end of the `CertFindChainInStore` enumeration is detected by matching the English error text `"Cannot find object or property."`. When English message resources aren't installed, Go's `syscall.Errno.Error()` returns the system-language message instead (French: `"Impossible de trouver l’objet ou la propriété."`), the match never succeeds, and the normal end of the enumeration is treated as a fatal error.

This change compares the error code instead of the message text. `CRYPT_E_NOT_FOUND` is what `CertFindChainInStore` documents for the end of the enumeration, and the `golang.org/x/sys/windows` wrapper returns it as a raw `syscall.Errno`, so it can be matched directly and is locale-independent:

```go
if errors.Is(err, syscall.Errno(windows.CRYPT_E_NOT_FOUND)) {
    break
}
```

Testing:
- On a French-language Windows Server 2019 (the affected platform): v1.8.4 fails `read-certificate-data` with the error above; with this patch the same command returns the certificate data and a full `credential-process` flow completes.
- On English-language Windows, stock and patched builds behave identically (no regression).
- `gofmt` and `go vet` are clean; the Windows build with the Makefile flags succeeds.
- No unit test added: the Windows cert store path has no test harness in the repo (it needs a real certificate store), consistent with the existing code.

Fixes #192

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
