### PR TITLE
fix(signer): reject unsupported public key algorithms in ReadCertificateData

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ PKCS8ENCRYPTEDKEYS := $(patsubst %.pem, %-pkcs8-scrypt.pem, $(RSAKEYS) $(ECKEYS)
 ECCERTS := $(foreach digest, sha1 sha256 sha384 sha512, $(patsubst %-key.pem, %-$(digest)-cert.pem, $(ECKEYS)))
 RSACERTS := $(foreach digest, md5 sha1 sha256 sha384 sha512, $(patsubst %-key.pem, %-$(digest)-cert.pem, $(RSAKEYS)))
 MLDSACERTS :=  $(foreach algo, mldsa44 mldsa65 mldsa87, $(patsubst %-key.pem, %-cert.pem, $(MLDSAKEYS)))
+ED25519KEY := $(certsdir)/ed25519-key.pem
+ED25519CERT := $(certsdir)/ed25519-cert.pem
 PKCS12CERTS := $(patsubst %-cert.pem, %.p12, $(RSACERTS) $(ECCERTS))
 
 # ML-DSA specific PKCS8 encrypted keys
@@ -303,6 +305,12 @@ endef
 %mldsa65-cert.pem: %mldsa65-key.pem; $(MLDSA_CERT_RECIPE)
 %mldsa87-cert.pem: %mldsa87-key.pem; $(MLDSA_CERT_RECIPE)
 
+# Ed25519 uses PureEdDSA with no external digest, so like ML-DSA it has no
+# digest in the filename and a self-signed cert is built without a -sha* flag.
+$(ED25519KEY):
+	openssl genpkey -algorithm ed25519 -out $@
+%ed25519-cert.pem: %ed25519-key.pem; $(MLDSA_CERT_RECIPE)
+
 %-combo.pem: %-cert.pem
 	KEY=$$(echo "$@" | sed 's/-[^-]*-combo.pem/-key.pem/'); \
 	cat $${KEY} $< > $@.tmp && mv $@.tmp $@
@@ -381,8 +389,9 @@ KEYS := $(RSAKEYS) $(ECKEYS) $(patsubst %-key.pem,%-key-pkcs8.pem,$(RSAKEYS) $(E
 		$(patsubst %.pem, %-pkcs8-$(prf).pem, $(RSAKEYS) $(ECKEYS))) \
 	$(foreach algo, aes-128-cbc aes-192-cbc aes-256-cbc, \
 		$(patsubst %.pem, %-pkcs8-$(subst -,,$(algo)).pem, $(RSAKEYS) $(ECKEYS)))
+KEYS += $(ED25519KEY)
 ALL_KEYS := $(KEYS) $(TPMKEYS)
-CERTS := $(RSACERTS) $(ECCERTS)
+CERTS := $(RSACERTS) $(ECCERTS) $(ED25519CERT)
 ALL_CERTS := $(CERTS) $(TPMCERTS)
 COMBOS := $(patsubst %-cert.pem, %-combo.pem, $(RSACERTS) $(ECCERTS))
 ALL_COMBOS := $(patsubst %-cert.pem, %-combo.pem, $(RSACERTS) $(ECCERTS) $(TPMCERTS))

--- a/aws_signing_helper/signer.go
+++ b/aws_signing_helper/signer.go
@@ -905,7 +905,7 @@ func ReadCertificateData(certificateId string) (CertificateData, *x509.Certifica
 		case x509.ECDSA:
 			keyType = "EC"
 		default:
-			keyType = ""
+			return CertificateData{}, nil, fmt.Errorf("unsupported public key algorithm: %s", cert.PublicKeyAlgorithm)
 		}
 
 		supportedAlgorithms = []string{

--- a/aws_signing_helper/signer_test.go
+++ b/aws_signing_helper/signer_test.go
@@ -63,6 +63,20 @@ func TestReadCertificateData(t *testing.T) {
 	}
 }
 
+func TestReadUnsupportedCertificateData(t *testing.T) {
+	// Ed25519 is parseable X.509 but not a signing algorithm this helper
+	// supports, so ReadCertificateData must reject it rather than reporting
+	// a bogus empty key type with SHA256/384/512 as supported algorithms.
+	_, _, err := ReadCertificateData("../tst/certs/ed25519-cert.pem")
+	if err == nil {
+		t.Log("Expected error for unsupported public key algorithm but got none")
+		t.Fail()
+	} else if !strings.Contains(err.Error(), "unsupported public key algorithm") {
+		t.Logf("Error doesn't contain expected text. Got: %v", err)
+		t.Fail()
+	}
+}
+
 func TestReadInvalidCertificateData(t *testing.T) {
 	_, _, err := ReadCertificateData("../tst/certs/invalid-rsa-cert.pem")
 	if err == nil {


### PR DESCRIPTION
ReadCertificateData's `default` switch case set an empty `keyType` for any public key algorithm outside {RSA, ECDSA, ML-DSA}, then unconditionally built `supportedAlgorithms` as `["SHA256","SHA384","SHA512"]` — advertising bogus prefix-less algorithms for certs the helper cannot sign (e.g. Ed25519).

This value is only surfaced by the `read-certificate-data` command; the request-signing path hardcodes `crypto.SHA256` (`signer.go`), so this is a diagnostic-only correctness fix, not a signing behavior change.

## Change
- Return an error for unsupported public key algorithms instead of emitting a bogus key type / algorithm list.
- Add an Ed25519 cert fixture (Makefile, following the existing ML-DSA no-digest idiom) and a regression test asserting the error.

## Testing
`go test ./aws_signing_helper/ -run TestReadCertificateData` (RSA/EC still pass), plus new `TestReadUnsupportedCertificateData` (Ed25519 → error).