### PR TITLE
ci: add daily scheduled security scans

### DIFF
--- a/.github/workflows/build_and_test_docker_image.yml
+++ b/.github/workflows/build_and_test_docker_image.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  schedule:
+    # Daily at 07:30 UTC. Re-scans the image so base-layer CVEs disclosed
+    # after the last PR/push still trip the Trivy release gate (scan-image.sh).
+    - cron: '30 7 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,21 @@
+name: govulncheck
+
+on:
+  schedule:
+    # Daily at 07:00 UTC. Catches CVEs newly disclosed against pinned deps.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
+        with:
+          go-version-file: go.mod


### PR DESCRIPTION
## Why

Newly-disclosed CVEs land against already-shipped artifacts *between* PRs. Event-triggered scanning alone lets vulnerable Go deps and Docker base images sit unflagged until the next change. This adds periodic re-scans to close that gap.

## Changes

- **New `govulncheck.yml`** — daily cron (`0 7 * * *`) + `workflow_dispatch`. Runs `golang/govulncheck-action@v1.1.0` (SHA-pinned) against `go.mod`; fails on any known vulnerability in Go dependencies.
- **`build_and_test_docker_image.yml`** — added `schedule` (`30 7 * * *`) + `workflow_dispatch` triggers. On `schedule`, every `github.event_name == 'push'` guard is false, so it reuses the existing PR path (build+`load`, verify, Trivy `scan-image.sh`) — no ECR push, no creds, `test-and-scan` job stays skipped — while keeping the release-blocking severity thresholds.

## Notes

- Scheduled workflows fire only from the default branch; these activate once merged to `main`. Use the `workflow_dispatch` button to test on the branch beforehand.
- govulncheck may surface findings requiring a `go.mod` bump to clear — that is the gate working as intended.