### PR TITLE
fix(serve): fail fast on cold-start error, retain valid creds on refresh failure

### DIFF
--- a/aws_signing_helper/serve.go
+++ b/aws_signing_helper/serve.go
@@ -28,6 +28,10 @@ const LocalHostAddress = "127.0.0.1"
 
 var RefreshTime = time.Minute * time.Duration(5)
 
+// The minimum time between CreateSession refresh attempts.
+var MinRefreshInterval = time.Minute * time.Duration(5)
+var CertExpiryWarningHorizon = time.Hour * 24 * time.Duration(30)
+
 type RefreshableCred struct {
 	AccessKeyId     string
 	SecretAccessKey string
@@ -96,7 +100,11 @@ func InsertToken(token string, expirationTime time.Time) error {
 		}
 
 		delete(tokenMap, earliestExpiringToken)
-		log.Printf("evicting earliest expiring token: %s", earliestExpiringToken)
+		if Debug {
+			log.Printf("evicting earliest expiring token: %s", earliestExpiringToken)
+		} else {
+			log.Printf("evicting earliest expiring token")
+		}
 	}
 	tokenMap[token] = expirationTime
 	mutex.Unlock()
@@ -155,6 +163,13 @@ func FindTokenTTLSeconds(r *http.Request) (string, error) {
 }
 
 func AllIssuesHandlers(cred *RefreshableCred, roleName string, opts *CredentialsOpts, signer Signer, signatureAlgorithm string) (http.HandlerFunc, http.HandlerFunc, http.HandlerFunc) {
+	// Serializes refresh attempts against the shared cred and throttles retries so
+	// a run of CreateSession failures does not call the API on every request.
+	var (
+		refreshMutex       sync.Mutex
+		lastRefreshAttempt time.Time
+	)
+
 	// Handles PUT requests to /latest/api/token/
 	putTokenHandler := func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "PUT" {
@@ -232,37 +247,47 @@ func AllIssuesHandlers(cred *RefreshableCred, roleName string, opts *Credentials
 
 		var nextRefreshTime = cred.Expiration.Add(-RefreshTime)
 		if time.Until(nextRefreshTime) < RefreshTime {
-			if Debug {
-				log.Println("Generating credentials")
+			refreshMutex.Lock()
+			if time.Since(lastRefreshAttempt) >= MinRefreshInterval {
+				lastRefreshAttempt = time.Now()
+				if Debug {
+					log.Println("Generating credentials")
+				}
+				credentialProcessOutput, gcErr := GenerateCredentials(opts, signer, signatureAlgorithm)
+				if gcErr != nil {
+					// Keep the last-known-good credentials.
+					log.Printf("Error generating credentials: %s\n", gcErr)
+				} else {
+					cred.AccessKeyId = credentialProcessOutput.AccessKeyId
+					cred.SecretAccessKey = credentialProcessOutput.SecretAccessKey
+					cred.Token = credentialProcessOutput.SessionToken
+					cred.Expiration, _ = time.Parse(time.RFC3339, credentialProcessOutput.Expiration)
+					cred.Code = REFRESHABLE_CRED_CODE
+					cred.LastUpdated = time.Now()
+					cred.Type = REFRESHABLE_CRED_TYPE
+				}
 			}
-			credentialProcessOutput, gcErr := GenerateCredentials(opts, signer, signatureAlgorithm)
-			if gcErr != nil {
-				log.Printf("Error generating credentials: %s\n", gcErr)
-			}
-			cred.AccessKeyId = credentialProcessOutput.AccessKeyId
-			cred.SecretAccessKey = credentialProcessOutput.SecretAccessKey
-			cred.Token = credentialProcessOutput.SessionToken
-			cred.Expiration, _ = time.Parse(time.RFC3339, credentialProcessOutput.Expiration)
-			cred.Code = REFRESHABLE_CRED_CODE
-			cred.LastUpdated = time.Now()
-			cred.Type = REFRESHABLE_CRED_TYPE
-			err := json.NewEncoder(w).Encode(cred)
+			refreshMutex.Unlock()
 
-			if err != nil {
+			// When a refresh failed or was throttled and no valid cached
+			// credentials remain to fall back on, surface the failure instead of
+			// returning empty credentials with a "Success" code.
+			if cred.AccessKeyId == "" || !time.Now().Before(cred.Expiration) {
+				log.Println("Error: no valid credentials available after refresh attempt")
 				w.WriteHeader(http.StatusInternalServerError)
-				io.WriteString(w, "failed to encode credentials")
+				io.WriteString(w, "failed to refresh credentials")
 				return
 			}
 		} else {
 			if Debug {
 				log.Println("Using previously obtained credentials")
 			}
-			err := json.NewEncoder(w).Encode(cred)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				io.WriteString(w, "failed to encode credentials")
-				return
-			}
+		}
+
+		if encErr := json.NewEncoder(w).Encode(cred); encErr != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			io.WriteString(w, "failed to encode credentials")
+			return
 		}
 
 		tokenTTL, err := FindTokenTTLSeconds(r)
@@ -305,7 +330,24 @@ func Serve(port int, credentialsOptions CredentialsOpts) {
 	}
 	defer signer.Close()
 
-	credentialProcessOutput, _ := GenerateCredentials(&credentialsOptions, signer, signatureAlgorithm)
+	if cert, certErr := signer.Certificate(); certErr == nil && cert != nil {
+		now := time.Now()
+		switch {
+		case now.After(cert.NotAfter):
+			log.Printf("warning: client certificate expired at %s; CreateSession will fail", cert.NotAfter.Format(time.RFC3339))
+		case now.Before(cert.NotBefore):
+			log.Printf("warning: client certificate is not valid until %s; CreateSession will fail", cert.NotBefore.Format(time.RFC3339))
+		case now.Add(CertExpiryWarningHorizon).After(cert.NotAfter):
+			log.Printf("warning: client certificate expires soon, at %s; rotate it to avoid authentication failures", cert.NotAfter.Format(time.RFC3339))
+		}
+	}
+
+	credentialProcessOutput, err := GenerateCredentials(&credentialsOptions, signer, signatureAlgorithm)
+	if err != nil {
+		// Fail fast.
+		log.Printf("failed to generate initial credentials: %s", err)
+		os.Exit(1)
+	}
 	refreshableCred.AccessKeyId = credentialProcessOutput.AccessKeyId
 	refreshableCred.SecretAccessKey = credentialProcessOutput.SecretAccessKey
 	refreshableCred.Token = credentialProcessOutput.SessionToken


### PR DESCRIPTION
*Description of changes:*
Fixes four defects in serve-mode (aws_signing_helper/serve.go) where CreateSession failures were masked and empty credentials were served as success. 

1. Fail fast on startup CreateSession failure. The initial GenerateCredentials error in Serve() was discarded, so the helper started the listener on 127.0.0.1:9911 while serving empty credentials. 

2. Retain valid credentials on refresh failure; signal failure otherwise. getCredentialsHandler previously overwrote the cached credential with the zero-valued result on refresh error and still returned HTTP 200 / Code: "Success". It now updates the cache only on success; on failure it keeps the last-known-good credential and serves it while still valid. When no valid credential remains, it returns HTTP 500 rather than empty-with-Success. A MinRefreshInterval  throttles retries so a run of failures does not call CreateSession on every request during the refresh window.

3. Gate token-eviction log behind the debug flag. The eviction log in InsertToken now only prints the token value when Debug is set, consistent with the existing expiry-cleanup path, keeping IMDSv2 session tokens out of logs by default.

4. Warn on certificate validity at startup. Serve() now inspects the client certificate after GetSigner and logs a clear warning when it is expired, not yet valid, or within 30 days of expiry (CertExpiryWarningHorizon, matching the Java plugin), so an expired cert is named explicitly instead of surfacing as an opaque CreateSession failure.

Built with `make clean` && `make release`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
